### PR TITLE
multi-repo bounties passing contract tests

### DIFF
--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -439,7 +439,7 @@ contract Projects is IsContract, AragonApp {
 
     /**
      * @notice add bulk bounties
-     * @param _repoId The id of the Github repo in the projects registry
+     * @param _repoIds The ids of the Github repos in the projects registry
      * @param _issueNumbers an array of bounty indexes
      * @param _bountySizes an array of bounty sizes
      * @param _deadlines an array of bounty deadlines
@@ -448,7 +448,7 @@ contract Projects is IsContract, AragonApp {
      * @param _ipfsAddresses a string of ipfs addresses
      */
     function addBounties(
-        bytes32 _repoId,
+        bytes32[] _repoIds,
         uint256[] _issueNumbers,
         uint256[] _bountySizes,
         uint256[] _deadlines,
@@ -485,7 +485,7 @@ contract Projects is IsContract, AragonApp {
 
             //Add bounty to local registry
             _addBounty(
-                _repoId,
+                _repoIds[i],
                 _issueNumbers[i],
                 standardBountyId,
                 _bountySizes[i]

--- a/apps/projects/test/projects.test.js
+++ b/apps/projects/test/projects.test.js
@@ -258,7 +258,7 @@ contract('Projects App', accounts => {
       beforeEach('issue bulk bounties', async () => {
         issue3Receipt = addedBounties(
           await app.addBounties(
-            repoId,
+            Array(3).fill(repoId),
             [1, 2, 3],
             [10, 20, 30],
             [Date.now() + 86400, Date.now() + 86400, Date.now() + 86400],
@@ -481,7 +481,7 @@ contract('Projects App', accounts => {
 
     it('cannot add bounties to unregistered repos', async () => {
       assertRevert(async () => {
-        await app.addBounties('0xdeadbeef', [1, 2, 3], [10, 20, 30], {
+        await app.addBounties(Array(3).fill('0xdeadbeef'), [1, 2, 3], [10, 20, 30], {
           from: bountyAdder,
         })
       })
@@ -496,7 +496,7 @@ contract('Projects App', accounts => {
         )
       )
       await app.addBounties(
-        repoId,
+        Array(3).fill(repoId),
         [1, 2, 3],
         [10, 20, 30],
         [Date.now() + 86400, Date.now() + 86400, Date.now() + 86400],
@@ -523,7 +523,7 @@ contract('Projects App', accounts => {
       )
       assertRevert(async () => {
         await app.addBounties(
-          repoId,
+          Array(3).fill(repoId),
           [1, 2, 3],
           [10, 20, 30], // 60 total Wei should be sent
           [Date.now() + 86400, Date.now() + 86400, Date.now() + 86400],


### PR DESCRIPTION
The Projects contract now accepts an array of repoIds, so each issue can originate from a different repo, as long as all repos have already been added to the contract. 