### PR TITLE
472 issue detail feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # That Planning Suite
 
-[![Build Status](https://img.shields.io/travis/AutarkLabs/planning-suite.svg?style=flat-square)](https://travis-ci.org/AutarkLabs/planning-suite) [![Coverage Status](https://coveralls.io/repos/github/AutarkLabs/planning-suite/badge.svg?branch=dev)](https://coveralls.io/github/AutarkLabs/planning-suite?branch=dev)
+[![Build Status](https://img.shields.io/travis/AutarkLabs/planning-suite.svg?style=flat-square)](https://travis-ci.org/AutarkLabs/planning-suite) [![Coverage Status](https://img.shields.io/coveralls/github/AutarkLabs/planning-suite.svg?style=flat-square)](https://coveralls.io/github/AutarkLabs/planning-suite)
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # That Planning Suite
 
-[![Build Status](https://img.shields.io/travis/AutarkLabs/planning-suite.svg?style=flat-square)](https://travis-ci.org/AutarkLabs/planning-suite) [![Coverage Status](https://img.shields.io/coveralls/github/AutarkLabs/planning-suite.svg?style=flat-square)](https://coveralls.io/github/AutarkLabs/planning-suite)
+[![Build Status](https://img.shields.io/travis/AutarkLabs/planning-suite.svg?style=flat-square)](https://travis-ci.org/AutarkLabs/planning-suite) [![Coverage Status](https://coveralls.io/repos/github/AutarkLabs/planning-suite/badge.svg?branch=dev)](https://coveralls.io/github/AutarkLabs/planning-suite?branch=dev)
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
   <a href="#development-setup">Development Setup</a> •
   <a href="#background">Background</a> •
   <a href="#details">Details</a> •
-  <a href="#design-concepts">Design Concepts</a>
+  <a href="#design-concepts">Design Concepts</a> •
   <a href="#contact">Contact</a>
 </p>
 <!-- markdownlint-enable MD033 -->
@@ -34,7 +34,7 @@ $ npm run start:range
 
 # current app name aliases: {address, projects, payout, range}
 ```
- 
+
 ### Extra tips
 
 - Individual development is ultra-fast thanks to parcel and hot module replacement.

--- a/apps/projects/app/components/App/App.js
+++ b/apps/projects/app/components/App/App.js
@@ -339,20 +339,22 @@ class App extends React.PureComponent {
     }))
   }
 
-  onReviewApplication = issue => {
+  onReviewApplication = (issue, requestIndex) => {
     this.closePanel()
     console.log('onReviewApplication Issue:', issue)
     console.log(
       'onReviewApplication submission:',
       web3.toHex(issue.repoId),
       issue.number,
-      issue.requestsData[0].contributorAddr
+      issue.requestsData[requestIndex].contributorAddr,
+      issue
     )
 
     this.props.app.approveAssignment(
       web3.toHex(issue.repoId),
       issue.number,
-      issue.requestsData[0].contributorAddr
+      issue.requestsData[requestIndex].contributorAddr,
+      issue.requestsData[requestIndex].requestIPFSHash
     )
   }
 
@@ -372,15 +374,17 @@ class App extends React.PureComponent {
       'onReviewWork',
       web3.toHex(issue.repoId),
       issue.number,
-      issue.assignee,
-      state.accepted
+      issue.workSubmissions[issue.workSubmissions.length - 1],
+      state.accepted,
+      issue.workSubmissions[issue.workSubmissions.length - 1].submissionIPFSHash
     )
     this.closePanel()
     this.props.app.reviewSubmission(
       web3.toHex(issue.repoId),
       issue.number,
-      issue.assignee,
-      state.accepted
+      issue.workSubmissions.length - 1,
+      state.accepted,
+      issue.workSubmissions[issue.workSubmissions.length - 1].submissionIPFSHash
     )
   }
 

--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -29,19 +29,19 @@ class ReviewApplication extends React.Component {
 
   onReviewApplication = () => {
     console.log('Accepted', this.state.feedback, this.props.issue)
-    this.props.onReviewApplication(this.props.issue)
+    this.props.onReviewApplication(this.props.issue, this.state.requestIndex)
   }
 
   changeRequest = (index) => {
     this.setState({requestIndex: index})
-  } 
+  }
 
 
   render() {
     const { issue } = this.props
 
     const request = issue.requestsData[this.state.requestIndex]
-    
+
     const application = {
       user: {
         login: request.user.login,
@@ -64,7 +64,7 @@ class ReviewApplication extends React.Component {
         noSeparator
       >
         <IssueTitle>{issue.title}</IssueTitle>
-        
+
         <DropDown
           name="Applicant"
           items={issue.requestsData.map( request => request.user.login)}

--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -369,6 +369,7 @@ contract Projects is IsContract, AragonApp {
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue up for assignment
      * @param _requestor address of user that will be assigned the issue
+     * @param _updatedApplication IPFS hash of the application containing optional feedback
      */
     function approveAssignment(
         bytes32 _repoId,
@@ -424,13 +425,14 @@ contract Projects is IsContract, AragonApp {
      * @param _issueNumber the github issue up for resolution
      * @param _submissionNumber submission index of the submitted work for review
      * @param _approved decision to accept the contribution
+     * @param _updatedSubmissionHash IPFS hash of the submission containing optional feedback
      */
     function reviewSubmission(
         bytes32 _repoId,
         uint256 _issueNumber,
         uint256 _submissionNumber,
         bool _approved,
-        string updatedSubmissionHash
+        string _updatedSubmissionHash
     ) external isInitialized auth(WORK_REVIEW_ROLE)
     {
         GithubIssue storage issue = repos[_repoId].issues[_issueNumber];
@@ -438,7 +440,7 @@ contract Projects is IsContract, AragonApp {
         require(!issue.fulfilled,"BOUNTY_FULFILLED");
 
         WorkSubmission storage submission = workSubmissions[issue.submissionIndices[_submissionNumber]];
-        submission.submissionHash = updatedSubmissionHash;
+        submission.submissionHash = _updatedSubmissionHash;
 
         if (_approved) {
             if (issue.hasBounty) {

--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -403,7 +403,7 @@ contract Projects is IsContract, AragonApp {
     }
 
     /**
-     * @notice Submit work for issue '`_issueNumber`'.
+     * @notice Submit work for issue `_issueNumber`.
      * @dev add a submission to local state after it's been added to StandardBounties.sol
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue up for assignment
@@ -438,7 +438,7 @@ contract Projects is IsContract, AragonApp {
     }
 
     /**
-     * @notice Review work submitted by '`_submissionNumber`'.
+     * @notice Review work submission.
      * @dev add a submission to local state after it's been added to StandardBounties.sol
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue up for resolution

--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -213,7 +213,6 @@ contract Projects is IsContract, AragonApp {
 
         for (uint256 i = 0; i < issuePriorities.length; i++) {
             repoId = bytes32(issueRepos[i]);
-            //require(issuePriorities[i] != 999, "issue already curated"); // This function is not yet executed by range voting so this is unnecessary
             repos[repoId].issues[uint256(issueNumbers[i])].priority = issuePriorities[i];
             emit IssueCurated(repoId);
         }
@@ -344,23 +343,6 @@ contract Projects is IsContract, AragonApp {
 ///////////////////
 // Bounty functions
 ///////////////////
-
-    ///**
-    // * @notice accept a given fulfillment
-    // * @dev may be used if a contributor submits a fulfillment outside of the projects app.
-    // * @param _repoId The id of the Github repo in the projects registry
-    // * @param _issueNumber the index of the bounty
-    // * @param _bountyFulfillmentId the index of the fulfillment being accepted
-    // */
-    //function acceptFulfillment(
-    //    bytes32 _repoId,
-    //    uint256 _issueNumber,
-    //    uint _bountyFulfillmentId
-    //) external auth(ADD_BOUNTY_ROLE)
-    //{
-    //    GithubIssue storage issue = repos[_repoId].issues[_issueNumber];
-    //    bounties.acceptFulfillment(issue.standardBountyId, _bountyFulfillmentId);
-    //}
 
     /**
      * @notice apply to be assigned to this issue by submitting timeline and workplan

--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -118,7 +118,7 @@ contract Projects is IsContract, AragonApp {
         uint standardBountyId;
         address assignee;
         address[] applicants;
-        uint256 submissionQty;
+        //uint256 submissionQty;
         uint256[] submissionIndices;
         mapping(address => string) assignmentRequests;
         //mapping(address => WorkSubmission) workSubmissions;
@@ -408,13 +408,11 @@ contract Projects is IsContract, AragonApp {
                 WorkSubmission(
                     SubmissionStatus.Unreviewed,
                     _submissionAddress,
-                    issue.submissionQty,
+                    issue.submissionIndices.length,
                     issue.assignee
                 )
             ) - 1 // push returns array length so we need to subtract 1 to get the index value
         );
-
-        issue.submissionQty += 1;
 
         emit WorkSubmitted(_repoId, _issueNumber);
     }
@@ -575,7 +573,7 @@ contract Projects is IsContract, AragonApp {
      * @notice Returns contributor's work submission
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue being worked on
-     * @param _submissionNumber the address of the contributor
+     * @param _submissionNumber the index of the contribution in the submissions Array
      * @return  application IPFS hash for the applicant's proposed timeline and strategy
      */
     function getSubmission(
@@ -652,7 +650,7 @@ contract Projects is IsContract, AragonApp {
             address(0),
             emptyAddressArray,
             //address(0),
-            0,
+            //0,
             emptySubmissionIndexArray
         );
         emit BountyAdded(

--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -38,20 +38,20 @@ interface Bounties {
         address _arbiter,
         bool _paysTokens,
         address _tokenContract
-    ) external returns (uint);  
+    ) external returns (uint);
 
     function activateBounty(
-        uint _bountyId, 
+        uint _bountyId,
         uint _value
     ) external payable;
 
     function fulfillBounty(
-        uint _bountyId, 
+        uint _bountyId,
         string _data
     ) public;
 
     function acceptFulfillment(
-        uint _bountyId, 
+        uint _bountyId,
         uint _fulfillmentId
     ) external;
 
@@ -119,8 +119,9 @@ contract Projects is IsContract, AragonApp {
         address[] applicants;
         address workSubmittor;
         uint256 submissionQty;
+        uint256[] submissionIndices;
         mapping(address => string) assignmentRequests;
-        mapping(address => WorkSubmission) workSubmissions;
+        //mapping(address => WorkSubmission) workSubmissions;
     }
 
     Vault public vault;
@@ -130,6 +131,9 @@ contract Projects is IsContract, AragonApp {
 
     // Gives us a repos array so we can actually iterate
     bytes32[] private repoIndex;
+
+    //holds all work submissions
+    WorkSubmission[] workSubmissions;
 
     // Fired when a repository is added to the registry.
     event RepoAdded(bytes32 indexed repoId, bytes20 owner, uint index);
@@ -141,8 +145,6 @@ contract Projects is IsContract, AragonApp {
     event BountyAdded(bytes20 owner, bytes32 repoId, uint256 issueNumber, uint256 bountySize);
     // Fired when an issue is curated
     event IssueCurated(bytes32 repoId);
-    // Fired when fulfillment is accepted
-    event FulfillmentAccepted(bytes32 repoId, uint256 issueNumber, uint fulfillmentId);
     // Fired when settings are changed
     event BountySettingsChanged();
     // Fired when user requests issue assignment
@@ -151,8 +153,10 @@ contract Projects is IsContract, AragonApp {
     event AssignmentApproved(address applicant, bytes32 indexed repoId, uint256 issueNumber);
     // Fired when a user submits work towards an issue
     event WorkSubmitted(bytes32 repoId, uint256 issueNumber);
-    //Fired when a reivew is accepted
-    event SubmissionAccepted(address submittor, bytes32 repoId, uint256 issueNumber);
+    // Fired when a reviewer accepts accepts a submission
+    event SubmissionAccepted(uint256 submissionNumber, bytes32 repoId, uint256 issueNumber);
+    // Fired when a reviewer rejects a submission
+    event SubmissionRejected(uint256 submissionNumber, bytes32 repoId, uint256 issueNumber);
 
     bytes32 public constant ADD_BOUNTY_ROLE =  keccak256("ADD_BOUNTY_ROLE");
     bytes32 public constant ADD_REPO_ROLE = keccak256("ADD_REPO_ROLE");
@@ -192,9 +196,9 @@ contract Projects is IsContract, AragonApp {
     }
 
     function curateIssues(
-        address[] /*unused_Addresses*/, 
+        address[] /*unused_Addresses*/,
         uint256[] issuePriorities,
-        uint256[] issueDescriptionIndices, 
+        uint256[] issueDescriptionIndices,
         string /* unused_issueDescriptions*/,
         uint256[] issueRepos,
         uint256[] issueNumbers,
@@ -214,7 +218,7 @@ contract Projects is IsContract, AragonApp {
             emit IssueCurated(repoId);
         }
     }
-    
+
 ///////////////////////
 // Set state functions
 ///////////////////////
@@ -298,7 +302,7 @@ contract Projects is IsContract, AragonApp {
 // Repository functions
 ///////////////////////
     /**
-     * @notice Add selected repository to Managed Projects 
+     * @notice Add selected repository to Managed Projects
      * @param _owner Github id of the entity that owns the repo to add
      * @param _repoId Github id of the repo to add
      * @return index for the added repo at the registry
@@ -356,7 +360,6 @@ contract Projects is IsContract, AragonApp {
     {
         GithubIssue storage issue = repos[_repoId].issues[_issueNumber];
         bounties.acceptFulfillment(issue.standardBountyId, _bountyFulfillmentId);
-        emit FulfillmentAccepted(_repoId, _issueNumber, _bountyFulfillmentId);
     }
 
     /**
@@ -366,10 +369,10 @@ contract Projects is IsContract, AragonApp {
      * @param _application IPFS hash for the applicant's proposed timeline and strategy
      */
     function requestAssignment(
-        bytes32 _repoId, 
-        uint256 _issueNumber, 
+        bytes32 _repoId,
+        uint256 _issueNumber,
         string _application
-    ) external isInitialized 
+    ) external isInitialized
     {
         require(bytes(repos[_repoId].issues[_issueNumber].assignmentRequests[msg.sender]).length == 0, "User already applied for this issue");
 
@@ -386,8 +389,8 @@ contract Projects is IsContract, AragonApp {
      * @param _requestor address of user that will be assigned the issue
      */
     function approveAssignment(
-        bytes32 _repoId, 
-        uint256 _issueNumber, 
+        bytes32 _repoId,
+        uint256 _issueNumber,
         address _requestor
     ) external isInitialized auth(TASK_ASSIGNMENT_ROLE)
     {
@@ -403,11 +406,11 @@ contract Projects is IsContract, AragonApp {
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue up for assignment
      * @param _submissionAddress IPFS hash of the Pull Request
-     * //param _fulfillmentId retrieved from event after the work is submitted to the bounties contract externally 
+     * //param _fulfillmentId retrieved from event after the work is submitted to the bounties contract externally
      */
     function submitWork(
-        bytes32 _repoId, 
-        uint256 _issueNumber, 
+        bytes32 _repoId,
+        uint256 _issueNumber,
         string _submissionAddress
         //uint256 _fulfillmentId
     ) external isInitialized
@@ -415,10 +418,14 @@ contract Projects is IsContract, AragonApp {
         require(msg.sender == repos[_repoId].issues[_issueNumber].assignee, "User not assigned to this issue");
         GithubIssue storage issue = repos[_repoId].issues[_issueNumber];
         bounties.fulfillBounty(issue.standardBountyId, _submissionAddress);
-        issue.workSubmissions[msg.sender] = WorkSubmission(
-            SubmissionStatus.Unreviewed,
-            _submissionAddress,
-            issue.submissionQty
+        issue.submissionIndices.push(
+            workSubmissions.push(
+                WorkSubmission(
+                    SubmissionStatus.Unreviewed,
+                    _submissionAddress,
+                    issue.submissionQty
+                )
+            )
         );
 
         issue.submissionQty += 1;
@@ -427,32 +434,35 @@ contract Projects is IsContract, AragonApp {
     }
 
     /**
-     * @notice Review work submitted by '`_contributor`'.
+     * @notice Review work submitted by '`_submissionNumber`'.
      * @dev add a submission to local state after it's been added to StandardBounties.sol
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue up for resolution
-     * @param _contributor address of the asignee who submitted work for review
-     * @param _approved decision to accept the contribution 
+     * @param _submissionNumber submission index of the submitted work for review
+     * @param _approved decision to accept the contribution
      */
     function reviewSubmission(
-        bytes32 _repoId, 
-        uint256 _issueNumber, 
-        address _contributor,
+        bytes32 _repoId,
+        uint256 _issueNumber,
+        uint256 _submissionNumber,
         bool _approved
     ) external isInitialized auth(WORK_REVIEW_ROLE)
     {
         GithubIssue storage issue = repos[_repoId].issues[_issueNumber];
+
         require(!issue.fulfilled,"Bounty already fulfilled");
+
+        WorkSubmission storage submission = workSubmissions[issue.submissionIndices[_submissionNumber]];
 
         if (_approved) {
             if (issue.hasBounty) {
-                bounties.acceptFulfillment(issue.standardBountyId, issue.workSubmissions[_contributor].fulfillmentId);
+                bounties.acceptFulfillment(issue.standardBountyId, submission.fulfillmentId);
             }
             issue.fulfilled = true;
-            issue.workSubmissions[_contributor].status = SubmissionStatus.Accepted;
-            emit SubmissionAccepted(_contributor, _repoId, _issueNumber);
+            submission.status = SubmissionStatus.Accepted;
+            emit SubmissionAccepted(_submissionNumber, _repoId, _issueNumber);
         } else {
-            issue.workSubmissions[_contributor].status = SubmissionStatus.Rejected;
+            submission.status = SubmissionStatus.Rejected;
         }
     }
 
@@ -483,7 +493,7 @@ contract Projects is IsContract, AragonApp {
         // submit the bounty to the StandardBounties contract
         for (uint i = 0; i < _bountySizes.length; i++) {
             ipfsHash = getHash(_ipfsAddresses, i);
-            
+
             standardBountyId = bounties.issueBounty(
                 this,                           //    address _issuer
                 _deadlines[i],                  //    uint256 _deadlines
@@ -534,9 +544,9 @@ contract Projects is IsContract, AragonApp {
      * @return  array length of the applicants array
      */
     function getApplicantsLength(
-        bytes32 _repoId, 
+        bytes32 _repoId,
         uint256 _issueNumber
-    ) public view returns(uint256 applicantQty) 
+    ) public view returns(uint256 applicantQty)
     {
         applicantQty = repos[_repoId].issues[_issueNumber].applicants.length;
     }
@@ -549,45 +559,43 @@ contract Projects is IsContract, AragonApp {
      * @return  applicant address
      */
     function getApplicant(
-        bytes32 _repoId, 
-        uint256 _issueNumber, 
+        bytes32 _repoId,
+        uint256 _issueNumber,
         uint256 _idx
-    ) public view returns(address applicant,string application) 
+    ) public view returns(address applicant,string application)
     {
         applicant = repos[_repoId].issues[_issueNumber].applicants[_idx];
         application = repos[_repoId].issues[_issueNumber].assignmentRequests[applicant];
     }
 
-    ///**
-    // * @notice Returns Applicant's Github Username
-    // * @param _repoId the github repo id of the issue
-    // * @param _issueNumber the github issue up for assignment
-    // * @param _applicant the address of the applicant
-    // * @return  application IPFS hash for the applicant's proposed timeline and strategy
-    // */
-    //function getAssignmentRequest(
-    //    bytes32 _repoId, 
-    //    uint256 _issueNumber, 
-    //    address _applicant
-    //) public view returns(string application) 
-    //{
-    //    application = repos[_repoId].issues[_issueNumber].assignmentRequests[_applicant];
-    //}
+        /**
+     * @notice Returns Applicant array length
+     * @param _repoId the github repo id of the issue
+     * @param _issueNumber the github issue up for assignmen
+     * @return  array length of the applicants array
+     */
+    function getSubmissionsLength(
+        bytes32 _repoId,
+        uint256 _issueNumber
+    ) public view returns(uint256 applicantQty)
+    {
+        applicantQty = repos[_repoId].issues[_issueNumber].submissionIndices.length;
+    }
 
     /**
      * @notice Returns contributor's work submission
      * @param _repoId the github repo id of the issue
      * @param _issueNumber the github issue being worked on
-     * @param _contributor the address of the contributor
+     * @param _submissionNumber the address of the contributor
      * @return  application IPFS hash for the applicant's proposed timeline and strategy
      */
     function getSubmission(
-        bytes32 _repoId, 
-        uint256 _issueNumber, 
-        address _contributor
-    ) public view returns(string submissionHash, uint256 fulfillmentId, SubmissionStatus status) 
+        bytes32 _repoId,
+        uint256 _issueNumber,
+        uint256 _submissionNumber
+    ) public view returns(string submissionHash, uint256 fulfillmentId, SubmissionStatus status)
     {
-        WorkSubmission memory submission = repos[_repoId].issues[_issueNumber].workSubmissions[_contributor];
+        WorkSubmission memory submission = workSubmissions[repos[_repoId].issues[_issueNumber].submissionIndices[_submissionNumber]];
         submissionHash = submission.submissionHash;
         fulfillmentId = submission.fulfillmentId;
         status = submission.status;
@@ -641,6 +649,7 @@ contract Projects is IsContract, AragonApp {
     ) internal
     {
         address[] memory emptyAddressArray;
+        uint256[] memory emptySubmissionIndexArray;
         repos[_repoId].issues[_issueNumber] = GithubIssue(
             _repoId,
             _issueNumber,
@@ -653,7 +662,8 @@ contract Projects is IsContract, AragonApp {
             address(0),
             emptyAddressArray,
             address(0),
-            0
+            0,
+            emptySubmissionIndexArray
         );
         emit BountyAdded(
             repos[_repoId].owner,
@@ -662,22 +672,6 @@ contract Projects is IsContract, AragonApp {
             _bountySize
         );
     }
-
-    // this function isn't used
-    //function checkTransValueEqualsMessageValue(
-    //    uint256 _msgValue,
-    //    uint256[] _bountySizes,
-    //    bool[] _tokenBounties
-    //) internal pure
-    //{
-    //    uint256 transValueTotal = 0;
-    //    for (uint i = 0; i < _bountySizes.length; i++) {
-    //        if (!(_tokenBounties[i])) {
-    //            transValueTotal = transValueTotal.add(_bountySizes[i]);
-    //        }
-    //    }
-    //    require(_msgValue == transValueTotal, "ETH sent to cover bounties does not match bounty total");
-    //}
 
     function getHash(
         string _str,

--- a/apps/projects/test/projects.test.js
+++ b/apps/projects/test/projects.test.js
@@ -408,12 +408,12 @@ contract('Projects App', accounts => {
       it('work can be accepted', async () => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
-        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber - 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
         await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
-        const submissionIndex = submissionQty.toNumber - 1
+        const submissionIndex = submissionQty.toNumber() - 1
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
 
         await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDl', { from: bountyAdder })
@@ -434,12 +434,12 @@ contract('Projects App', accounts => {
       it('work cannot be accepted or submitted after bounty is fulfilled', async () => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
-        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber - 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
         await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
-        const submissionIndex = submissionQty.toNumber - 1
+        const submissionIndex = submissionQty.toNumber() - 1
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
 
         await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDl', { from: bountyAdder })

--- a/apps/projects/test/projects.test.js
+++ b/apps/projects/test/projects.test.js
@@ -362,7 +362,7 @@ contract('Projects App', accounts => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
         applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
-        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+        await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         const issue = await app.getIssue(repoId, 1)
         assert.strictEqual(issue[6], root, 'assignee address incorrect')
@@ -372,7 +372,7 @@ contract('Projects App', accounts => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
         applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
-        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+        await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
@@ -389,14 +389,14 @@ contract('Projects App', accounts => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
         applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
-        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+        await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
         const submissionIndex = submissionQty.toNumber() - 1
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
 
-        await app.reviewSubmission(repoId, issueNumber, submissionIndex, false, { from: bountyAdder })
+        await app.reviewSubmission(repoId, issueNumber, submissionIndex, false, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDl', { from: bountyAdder })
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
         assert.strictEqual(
           submission[2].toNumber(),
@@ -409,14 +409,14 @@ contract('Projects App', accounts => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
         applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber - 1)
-        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+        await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
         const submissionIndex = submissionQty.toNumber - 1
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
 
-        await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, { from: bountyAdder })
+        await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDl', { from: bountyAdder })
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
         assert.strictEqual(
           submission[2].toNumber(),
@@ -435,14 +435,14 @@ contract('Projects App', accounts => {
         await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
         applicantQty = await app.getApplicantsLength(repoId, 1)
         applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber - 1)
-        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+        await app.approveAssignment(repoId, issueNumber, applicant[0], 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDe', { from: bountyAdder })
 
         await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
         const submissionIndex = submissionQty.toNumber - 1
         submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
 
-        await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, { from: bountyAdder })
+        await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDl', { from: bountyAdder })
         assertRevert(async () => {
           await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
         })
@@ -451,7 +451,7 @@ contract('Projects App', accounts => {
         })
       })
 
-      it('fulfill bounties and accept fulfillment', async () => {
+      xit('fulfill bounties and accept fulfillment', async () => {
         const IssueData1 = await app.getIssue(repoId, 1)
         const bountyId1 = IssueData1[1].toNumber()
         const fulfillmentId1 = fulfilledBounty(
@@ -501,7 +501,7 @@ contract('Projects App', accounts => {
         assert(fulfillment3[0] === true)
       })
 
-      it('verify balance is correct before and after accepting fulfillment in standard bounty', async () => {
+      xit('verify balance is correct before and after accepting fulfillment in standard bounty', async () => {
         const IssueData1 = await app.getIssue(repoId, 1)
         const bountyId1 = IssueData1[1].toNumber()
         const fulfillmentId1 = fulfilledBounty(
@@ -745,7 +745,7 @@ contract('Projects App', accounts => {
       })
     })
 
-    it('cannot accept unfulfilled bounties', async () => {
+    xit('cannot accept unfulfilled bounties', async () => {
       let repoId = addedRepo(
         await app.addRepo(
           'MDEyOk9yZ2FuaXphdGlvbjM0MDE4MzU5',
@@ -774,7 +774,7 @@ contract('Projects App', accounts => {
       assert(fulfillment1[0] === true)
     })
 
-    it('cannot issue bulk bounties with mismatched values', async () => {
+    xit('cannot issue bulk bounties with mismatched values', async () => {
       const bountyAdder = accounts[2]
       const repoId = addedRepo(
         await app.addRepo('abc', String(123), { from: owner1 })

--- a/apps/projects/test/projects.test.js
+++ b/apps/projects/test/projects.test.js
@@ -21,7 +21,7 @@ const fulfilledBounty = receipt =>
 
 contract('Projects App', accounts => {
   let daoFact,
-    registry,
+    bounties,
     app = {}
 
   const root = accounts[0]
@@ -47,7 +47,7 @@ contract('Projects App', accounts => {
     const dao = Kernel.at(
       r.logs.filter(l => l.event == 'DeployDAO')[0].args.dao
     )
-      
+
     const acl = ACL.at(await dao.acl())
 
     //Create DAO admin role
@@ -105,9 +105,33 @@ contract('Projects App', accounts => {
       root,
       { from: root }
     )
-    
+
+    await acl.createPermission(
+      bountyAdder,
+      app.address,
+      await app.TASK_ASSIGNMENT_ROLE(),
+      root,
+      { from: root }
+    )
+
+    await acl.createPermission(
+      bountyAdder,
+      app.address,
+      await app.WORK_REVIEW_ROLE(),
+      root,
+      { from: root }
+    )
+
+    await acl.createPermission(
+      root,
+      app.address,
+      await app.CHANGE_SETTINGS_ROLE(),
+      root,
+      { from: root }
+    )
+
     // Deploy test Bounties contract
-    registry = await StandardBounties.new(web3.toBigNumber(owner1))
+    bounties = await StandardBounties.new(web3.toBigNumber(owner1))
     vault = await Vault.new()
 
     await acl.createPermission(
@@ -118,9 +142,9 @@ contract('Projects App', accounts => {
       { from: root }
     )
 
-    bounties = StandardBounties.at(registry.address)
+    //bounties = StandardBounties.at(registry.address)
 
-    await app.initialize(registry.address, vault.address)
+    await app.initialize(bounties.address, vault.address)
   })
 
   context('creating and retrieving repos and bounties', () => {
@@ -159,6 +183,18 @@ contract('Projects App', accounts => {
       )
     })
 
+    it('can remove repos', async () => {
+      repoId2 = addedRepo(
+        await app.addRepo(
+          'MDawOlJlcG9zaXRvcnk3NTM5NTIyNA==', // repoId
+          'MDQ6VXNlcjUwMzAwNTk=', // ownerId
+          { from: owner1 }
+        )
+      )
+      app.removeRepo(repoId, { from: repoRemover })
+      app.removeRepo(repoId2, { from: repoRemover })
+    })
+
     context('standard bounty verification tests', () => {
       beforeEach(async () => {
         await bounties.issueBounty(
@@ -173,8 +209,8 @@ contract('Projects App', accounts => {
         )
       })
 
-      it('verifies that the StandardBounties registry works', async () => {
-        let owner = await registry.owner()
+      it('StandardBounties Deployed Correctly', async () => {
+        let owner = await bounties.owner()
         assert(owner == accounts[0])
       })
 
@@ -188,20 +224,20 @@ contract('Projects App', accounts => {
       })
 
       it('verifies that basic fulfillment acceptance flow works', async () => {
-        await registry.activateBounty(0, 1000, {
+        await bounties.activateBounty(0, 1000, {
           from: accounts[0],
           value: 1000,
         })
-        await registry.fulfillBounty(0, 'data', { from: accounts[1] })
-        let fulfillment = await registry.getFulfillment(0, 0)
+        await bounties.fulfillBounty(0, 'data', { from: accounts[1] })
+        let fulfillment = await bounties.getFulfillment(0, 0)
         assert(fulfillment[0] === false)
-        await registry.acceptFulfillment(0, 0, { from: accounts[0] })
-        fulfillment = await registry.getFulfillment(0, 0)
+        await bounties.acceptFulfillment(0, 0, { from: accounts[0] })
+        fulfillment = await bounties.getFulfillment(0, 0)
         assert(fulfillment[0] === true)
       })
 
-      it('verifies that bounty fulfillment flow works to completion', async () => {
-        await registry.issueBounty(
+      it('verifies that bounty fulfillment completes', async () => {
+        await bounties.issueBounty(
           accounts[0],
           2528821098,
           'data',
@@ -211,22 +247,22 @@ contract('Projects App', accounts => {
           0x0,
           { from: accounts[0] }
         )
-        await registry.activateBounty(0, 1000, {
+        await bounties.activateBounty(0, 1000, {
           from: accounts[0],
           value: 1000,
         })
-        await registry.fulfillBounty(0, 'data', { from: accounts[1] })
-        let fulfillment = await registry.getFulfillment(0, 0)
+        await bounties.fulfillBounty(0, 'data', { from: accounts[1] })
+        let fulfillment = await bounties.getFulfillment(0, 0)
         assert(fulfillment[0] === false)
-        await registry.acceptFulfillment(0, 0, { from: accounts[0] })
-        fulfillment = await registry.getFulfillment(0, 0)
-        const bounty = await registry.getBounty(0)
+        await bounties.acceptFulfillment(0, 0, { from: accounts[0] })
+        fulfillment = await bounties.getFulfillment(0, 0)
+        const bounty = await bounties.getBounty(0)
         assert(fulfillment[0] === true)
         assert(bounty[5] == 0)
       })
 
       it('verifies that bounty fulfillment flow works to completion with several fulfillments', async () => {
-        await registry.issueBounty(
+        await bounties.issueBounty(
           accounts[0],
           2528821098,
           'data',
@@ -236,17 +272,17 @@ contract('Projects App', accounts => {
           0x0,
           { from: accounts[0] }
         )
-        await registry.activateBounty(0, 1000, {
+        await bounties.activateBounty(0, 1000, {
           from: accounts[0],
           value: 1000,
         })
-        await registry.fulfillBounty(0, 'data', { from: accounts[1] })
-        await registry.fulfillBounty(0, 'data2', { from: accounts[2] })
-        let fulfillment = await registry.getFulfillment(0, 0)
+        await bounties.fulfillBounty(0, 'data', { from: accounts[1] })
+        await bounties.fulfillBounty(0, 'data2', { from: accounts[2] })
+        let fulfillment = await bounties.getFulfillment(0, 0)
         assert(fulfillment[0] === false)
-        await registry.acceptFulfillment(0, 0, { from: accounts[0] })
-        fulfillment = await registry.getFulfillment(0, 0)
-        const bounty = await registry.getBounty(0)
+        await bounties.acceptFulfillment(0, 0, { from: accounts[0] })
+        fulfillment = await bounties.getFulfillment(0, 0)
+        const bounty = await bounties.getBounty(0)
         assert(fulfillment[0] === true)
         assert(bounty[5] == 0)
       })
@@ -254,6 +290,7 @@ contract('Projects App', accounts => {
 
     context('issue, fulfill, and accept fulfillment for bulk bounties', () => {
       let issue3Receipt
+      const issueNumber = 1
 
       beforeEach('issue bulk bounties', async () => {
         issue3Receipt = addedBounties(
@@ -299,13 +336,128 @@ contract('Projects App', accounts => {
         )
       })
 
+      it('allows users to request assignment', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        response = await app.getApplicant(repoId, issueNumber, 0)
+        assert.strictEqual(
+          response[0],
+          root,
+          'applicant address incorrect'
+        )
+        assert.strictEqual(
+          response[1],
+          'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd',
+          'application IPFS hash incorrect'
+        )
+      })
+
+      it('users cannot apply for a given issue more than once', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        assertRevert( async () =>{
+          await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        })
+      })
+
+      it('assign tasks to applicants', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        applicantQty = await app.getApplicantsLength(repoId, 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
+        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+
+        const issue = await app.getIssue(repoId, 1)
+        assert.strictEqual(issue[6], root, 'assignee address incorrect')
+      })
+
+      it('users can submit work', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        applicantQty = await app.getApplicantsLength(repoId, 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
+        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+
+        await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
+        submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
+        submission = await app.getSubmission(repoId, issueNumber, submissionQty.toNumber() - 1)
+        assert.strictEqual(
+          submission[0],
+          'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk',
+          'submission incorrect'
+        )
+
+      })
+
+      it('work can be rejected', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        applicantQty = await app.getApplicantsLength(repoId, 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber() - 1)
+        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+
+        await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
+        submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
+        const submissionIndex = submissionQty.toNumber() - 1
+        submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
+
+        await app.reviewSubmission(repoId, issueNumber, submissionIndex, false, { from: bountyAdder })
+        submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
+        assert.strictEqual(
+          submission[2].toNumber(),
+          2,
+          'submission status not rejected'
+        )
+      })
+
+      it('work can be accepted', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        applicantQty = await app.getApplicantsLength(repoId, 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber - 1)
+        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+
+        await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
+        submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
+        const submissionIndex = submissionQty.toNumber - 1
+        submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
+
+        await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, { from: bountyAdder })
+        submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
+        assert.strictEqual(
+          submission[2].toNumber(),
+          1,
+          'submission status not accepted'
+        )
+      })
+
+      it('users cannot submit work for an issue they are not assigned to', async () => {
+        assertRevert( async () => {
+          await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
+        })
+      })
+
+      it('work cannot be accepted or submitted after bounty is fulfilled', async () => {
+        await app.requestAssignment(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDd', { from: root })
+        applicantQty = await app.getApplicantsLength(repoId, 1)
+        applicant = await app.getApplicant(repoId, issueNumber, applicantQty.toNumber - 1)
+        await app.approveAssignment(repoId, issueNumber, applicant[0], { from: bountyAdder })
+
+        await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
+        submissionQty = await app.getSubmissionsLength(repoId, issueNumber)
+        const submissionIndex = submissionQty.toNumber - 1
+        submission = await app.getSubmission(repoId, issueNumber, submissionIndex)
+
+        await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, { from: bountyAdder })
+        assertRevert(async () => {
+          await app.submitWork(repoId, issueNumber, 'QmbUSy8HCn8J4TMDRRdxCbK2uCCtkQyZtY6XYv3y7kLgDk')
+        })
+        assertRevert(async () => {
+          await app.reviewSubmission(repoId, issueNumber, submissionIndex, true, { from: bountyAdder })
+        })
+      })
+
       it('fulfill bounties and accept fulfillment', async () => {
         const IssueData1 = await app.getIssue(repoId, 1)
         const bountyId1 = IssueData1[1].toNumber()
         const fulfillmentId1 = fulfilledBounty(
-          await registry.fulfillBounty(bountyId1, 'findthemillenniumfalcon')
+          await bounties.fulfillBounty(bountyId1, 'findthemillenniumfalcon')
         )._fulfillmentId.toNumber()
-        let fulfillment1 = await registry.getFulfillment(
+        let fulfillment1 = await bounties.getFulfillment(
           bountyId1,
           fulfillmentId1
         )
@@ -313,15 +465,15 @@ contract('Projects App', accounts => {
         await app.acceptFulfillment(repoId, 1, fulfillmentId1, {
           from: bountyAdder,
         })
-        fulfillment1 = await registry.getFulfillment(bountyId1, fulfillmentId1)
+        fulfillment1 = await bounties.getFulfillment(bountyId1, fulfillmentId1)
         assert(fulfillment1[0] === true)
 
         const IssueData2 = await app.getIssue(repoId, 2)
         const bountyId2 = IssueData2[1].toNumber()
         const fulfillmentId2 = fulfilledBounty(
-          await registry.fulfillBounty(bountyId2, 'findthemillenniumfalcon')
+          await bounties.fulfillBounty(bountyId2, 'findthemillenniumfalcon')
         )._fulfillmentId.toNumber()
-        let fulfillment2 = await registry.getFulfillment(
+        let fulfillment2 = await bounties.getFulfillment(
           bountyId2,
           fulfillmentId2
         )
@@ -329,15 +481,15 @@ contract('Projects App', accounts => {
         await app.acceptFulfillment(repoId, 2, fulfillmentId2, {
           from: bountyAdder,
         })
-        fulfillment2 = await registry.getFulfillment(bountyId2, fulfillmentId2)
+        fulfillment2 = await bounties.getFulfillment(bountyId2, fulfillmentId2)
         assert(fulfillment2[0] === true)
 
         const IssueData3 = await app.getIssue(repoId, 3)
         const bountyId3 = IssueData3[1].toNumber()
         const fulfillmentId3 = fulfilledBounty(
-          await registry.fulfillBounty(bountyId3, 'findthemillenniumfalcon')
+          await bounties.fulfillBounty(bountyId3, 'findthemillenniumfalcon')
         )._fulfillmentId.toNumber()
-        let fulfillment3 = await registry.getFulfillment(
+        let fulfillment3 = await bounties.getFulfillment(
           bountyId3,
           fulfillmentId3
         )
@@ -345,7 +497,7 @@ contract('Projects App', accounts => {
         await app.acceptFulfillment(repoId, 3, fulfillmentId3, {
           from: bountyAdder,
         })
-        fulfillment3 = await registry.getFulfillment(bountyId3, fulfillmentId3)
+        fulfillment3 = await bounties.getFulfillment(bountyId3, fulfillmentId3)
         assert(fulfillment3[0] === true)
       })
 
@@ -353,61 +505,61 @@ contract('Projects App', accounts => {
         const IssueData1 = await app.getIssue(repoId, 1)
         const bountyId1 = IssueData1[1].toNumber()
         const fulfillmentId1 = fulfilledBounty(
-          await registry.fulfillBounty(bountyId1, 'findthemillenniumfalcon')
+          await bounties.fulfillBounty(bountyId1, 'findthemillenniumfalcon')
         )._fulfillmentId.toNumber()
-        let fulfillment1 = await registry.getFulfillment(
+        let fulfillment1 = await bounties.getFulfillment(
           bountyId1,
           fulfillmentId1
         )
         assert(fulfillment1[0] === false)
-        let bounty1 = await registry.getBounty(bountyId1)
+        let bounty1 = await bounties.getBounty(bountyId1)
         assert.strictEqual(bounty1[5].toNumber(), 10)
         await app.acceptFulfillment(repoId, 1, fulfillmentId1, {
           from: bountyAdder,
         })
-        fulfillment1 = await registry.getFulfillment(bountyId1, fulfillmentId1)
+        fulfillment1 = await bounties.getFulfillment(bountyId1, fulfillmentId1)
         assert(fulfillment1[0] === true)
-        bounty1 = await registry.getBounty(bountyId1)
+        bounty1 = await bounties.getBounty(bountyId1)
         assert.strictEqual(bounty1[5].toNumber(), 0)
 
         const IssueData2 = await app.getIssue(repoId, 2)
         const bountyId2 = IssueData2[1].toNumber()
         const fulfillmentId2 = fulfilledBounty(
-          await registry.fulfillBounty(bountyId2, 'findthemillenniumfalcon')
+          await bounties.fulfillBounty(bountyId2, 'findthemillenniumfalcon')
         )._fulfillmentId.toNumber()
-        let fulfillment2 = await registry.getFulfillment(
+        let fulfillment2 = await bounties.getFulfillment(
           bountyId2,
           fulfillmentId2
         )
         assert(fulfillment2[0] === false)
-        let bounty2 = await registry.getBounty(bountyId2)
+        let bounty2 = await bounties.getBounty(bountyId2)
         assert.strictEqual(bounty2[5].toNumber(), 20)
         await app.acceptFulfillment(repoId, 2, fulfillmentId2, {
           from: bountyAdder,
         })
-        fulfillment2 = await registry.getFulfillment(bountyId2, fulfillmentId2)
+        fulfillment2 = await bounties.getFulfillment(bountyId2, fulfillmentId2)
         assert(fulfillment2[0] === true)
-        bounty2 = await registry.getBounty(bountyId2)
+        bounty2 = await bounties.getBounty(bountyId2)
         assert.strictEqual(bounty2[5].toNumber(), 0)
 
         const IssueData3 = await app.getIssue(repoId, 3)
         const bountyId3 = IssueData3[1].toNumber()
         const fulfillmentId3 = fulfilledBounty(
-          await registry.fulfillBounty(bountyId3, 'findthemillenniumfalcon')
+          await bounties.fulfillBounty(bountyId3, 'findthemillenniumfalcon')
         )._fulfillmentId.toNumber()
-        let fulfillment3 = await registry.getFulfillment(
+        let fulfillment3 = await bounties.getFulfillment(
           bountyId3,
           fulfillmentId3
         )
         assert(fulfillment3[0] === false)
-        let bounty3 = await registry.getBounty(bountyId3)
+        let bounty3 = await bounties.getBounty(bountyId3)
         assert.strictEqual(bounty3[5].toNumber(), 30)
         await app.acceptFulfillment(repoId, 3, fulfillmentId3, {
           from: bountyAdder,
         })
-        fulfillment3 = await registry.getFulfillment(bountyId3, fulfillmentId3)
+        fulfillment3 = await bounties.getFulfillment(bountyId3, fulfillmentId3)
         assert(fulfillment3[0] === true)
-        bounty3 = await registry.getBounty(bountyId3)
+        bounty3 = await bounties.getBounty(bountyId3)
         assert.strictEqual(bounty3[5].toNumber(), 0)
       })
     })
@@ -417,7 +569,7 @@ contract('Projects App', accounts => {
     // TODO: We should create every permission for every test this way to speed up testing
     // TODO: Create an external helper function that inits acl and sets permissions
     before(async () => {})
-    it('should curate a single issue', async () => {
+    it('should curate a multiple issues', async () => {
       const unusedAddresses = accounts.slice(0, 4)
       const zeros = new Array(unusedAddresses.length).fill(0)
       const issuePriorities = zeros
@@ -437,21 +589,69 @@ contract('Projects App', accounts => {
       )
       // assert()
     })
-    xit('should curate multiple issues', async () => {
-      // assert()
-    })
     context('invalid issue curation operations', () => {
-      xit('should revert on unusedAddresses length mismatch', async () => {
-        // assert()
+      it('should revert on issueDescriptionindices and priorities array length mismatch', async () => {
+        const unusedAddresses = accounts.slice(0, 4)
+        const zeros = new Array(unusedAddresses.length).fill(0)
+        const issuePriorities = zeros
+        const issueDescriptionIndices = zeros.slice(0, 3)
+        const unused_issueDescriptions = ''
+        const issueRepos = zeros
+        const issueNumbers = zeros
+        const unused_curationId = 0
+        assertRevert(async () => {
+          await app.curateIssues(
+            unusedAddresses,
+            issuePriorities,
+            issueDescriptionIndices,
+            unused_issueDescriptions,
+            issueRepos,
+            issueNumbers,
+            unused_curationId
+          )
+        })
       })
-      xit('should revert on unusedAddresses length mismatch', async () => {
-        // assert()
+      it('should revert on IssuedescriptionIndices and issueRepos array length mismatch', async () => {
+        const unusedAddresses = accounts.slice(0, 4)
+        const zeros = new Array(unusedAddresses.length).fill(0)
+        const issuePriorities = zeros
+        const issueDescriptionIndices = zeros
+        const unused_issueDescriptions = ''
+        const issueRepos = zeros.slice(0, 3)
+        const issueNumbers = zeros
+        const unused_curationId = 0
+        assertRevert(async () => {
+          await app.curateIssues(
+            unusedAddresses,
+            issuePriorities,
+            issueDescriptionIndices,
+            unused_issueDescriptions,
+            issueRepos,
+            issueNumbers,
+            unused_curationId
+          )
+        })
       })
-      xit('should revert on unusedAddresses length mismatch', async () => {
-        // assert()
-      })
-      xit('should revert on unusedAddresses length mismatch', async () => {
-        // assert()
+      it('should revert on IssueRepos and IssuesNumbers array length mismatch', async () => {
+        const unusedAddresses = accounts.slice(0, 4)
+        const zeros = new Array(unusedAddresses.length).fill(0)
+        const issuePriorities = zeros
+        const issueDescriptionIndices = zeros
+        const unused_issueDescriptions = ''
+        const issueRepos = zeros
+        const issueNumbers = zeros.slice(0, 3)
+        const unused_curationId = 0
+        assertRevert(async () => {
+          await app.curateIssues(
+            unusedAddresses,
+            issuePriorities,
+            issueDescriptionIndices,
+            unused_issueDescriptions,
+            issueRepos,
+            issueNumbers,
+            unused_curationId
+          )
+        })
       })
       xit('should revert if an issue has an already assigned bounty', async () => {
         // assert()
@@ -459,7 +659,65 @@ contract('Projects App', accounts => {
     })
   })
 
+  context('settings management', () => {
+    it('can change Bounty Settings', async () => {
+      await app.changeBountySettings(
+        '100\tBeginner\t300\tIntermediate\t500\tAdvanced',  // Experience Levels
+        1,  // baseRate
+        336,  // bountyDeadline
+        'autark',   // bountyCurrency
+        bounties.address,  // bountyAllocator
+        0x0000000000000000000000000000000000000000  //bountyArbiter
+      )
+
+      response = await app.getSettings()
+      assert.strictEqual(
+        response[0],
+        '100\tBeginner\t300\tIntermediate\t500\tAdvanced',
+        'experience levels stored incorrectly'
+      )
+
+      assert.strictEqual(
+        response[1].toNumber(),
+        1,
+        'baseRate Incorrect'
+      )
+      assert.strictEqual(
+        response[2].toNumber(),
+        336,
+        'bounty deadline inccorrect'
+      )
+      assert.strictEqual(
+        response[3],
+        'autark',
+        'currency name incorrect'
+      )
+      assert.strictEqual(
+        response[4],
+        bounties.address,
+        'StandardBounties Contract address incorrect'
+      )
+      assert.strictEqual(
+        response[5],
+        '0x0000000000000000000000000000000000000000',
+        'arbiter incorrect'
+      )
+    })
+  })
+
   context('invalid operations', () => {
+    it('cannot add a repo that is already present', async () => {
+      await app.addRepo('abc', String(123), { from: owner1 })
+
+      assertRevert(async () => {
+        await app.addRepo('abc', String(123), { from: owner1 })
+      })
+    })
+    it('cannot remove a repo that was never added', async() => {
+      assertRevert(async () => {
+        await app.removeRepo('99999', { from: repoRemover })
+      })
+    })
     it('cannot retrieve a removed Repo', async () => {
       const repoId = addedRepo(
         await app.addRepo('abc', String(123), { from: owner1 })
@@ -508,11 +766,11 @@ contract('Projects App', accounts => {
       assertRevert(async () => {
         await app.acceptFulfillment(repoId, 0, 0, { from: bountyAdder })
       })
-      await registry.fulfillBounty(0, 'findthemillenniumfalcon')
-      let fulfillment1 = await registry.getFulfillment(0, 0)
+      await bounties.fulfillBounty(0, 'findthemillenniumfalcon')
+      let fulfillment1 = await bounties.getFulfillment(0, 0)
       assert(fulfillment1[0] === false)
       await app.acceptFulfillment(repoId, 0, 0, { from: bountyAdder })
-      fulfillment1 = await registry.getFulfillment(0, 0)
+      fulfillment1 = await bounties.getFulfillment(0, 0)
       assert(fulfillment1[0] === true)
     })
 


### PR DESCRIPTION
The following is addressed in this PR:
- Projects contract test coverage expanded (#413)
- All submmissions are now exposed in the frontend, and contain the Ethereum address of the submitter
- Feedback can now be submitted to the contractvia a new  IPFS hash in `approveAssignment` and `reviewSubmission` that contains both the initial information and the feedback. (#472) Currently in the frontend the pre-existing IPFS hash is resubmitted until further enhancements are made to the frontend  to expose this feedback to the users.
