### PR TITLE
907 Resolve repoIndex out-of-bounds revert

### DIFF
--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -547,7 +547,10 @@ contract Projects is IsContract, AragonApp {
      * @return _repoId Id for newly added repo
      */
     function isRepoAdded(bytes32 _repoId) public view returns(bool isAdded) {
+        uint256 repoIdxVal = repos[_repoId].index;
         if (repoIndex.length == 0)
+            return false;
+        if (repoIdxVal >= repoIndex.length)
             return false;
         return (repoIndex[repos[_repoId].index] == _repoId);
     }

--- a/apps/projects/test/projects.test.js
+++ b/apps/projects/test/projects.test.js
@@ -238,9 +238,8 @@ contract('Projects App', accounts => {
             { from: owner1 }
           )
         )
-
         await app.removeRepo(repoId, { from: repoRemover })
-        assert.isFalse(await app.isRepoAdded(repoId), 'repo at in the middle of the array should have been removed')
+        assert.isFalse(await app.isRepoAdded(repoId), 'repo in the middle of the array should have been removed')
         assert.isTrue(await app.isRepoAdded(repoId2), 'repo2 should still be accessible')
       })
 

--- a/apps/projects/test/projects.test.js
+++ b/apps/projects/test/projects.test.js
@@ -187,6 +187,7 @@ contract('Projects App', accounts => {
           repoIdString, // TODO: extract to a variable
           'repo is created and ID is returned'
         )
+        assert.isTrue(await app.isRepoAdded(repoId), 'repo should have been removed')
       })
 
       it('retrieve repo array length', async () => {
@@ -211,8 +212,36 @@ contract('Projects App', accounts => {
             { from: owner1 }
           )
         )
-        app.removeRepo(repoId, { from: repoRemover })
-        app.removeRepo(repoId2, { from: repoRemover })
+        repoId3 = addedRepo(
+          await app.addRepo(
+            'DRawOlJlcG9zaXRvcnk3NTM5NTIyNA==', // repoId
+            { from: owner1 }
+          )
+        )
+        await app.removeRepo(repoId3, { from: repoRemover })
+        assert.isFalse(await app.isRepoAdded(repoId3), 'repo at end of array should have been removed')
+        assert.isTrue(await app.isRepoAdded(repoId2), 'repo2 should still be accessible')
+
+        repoId3 = addedRepo(
+          await app.addRepo(
+            'DRawOlJlcG9zaXRvcnk3NTM5NTIyNA==', // repoId
+            { from: owner1 }
+          )
+        )
+        await app.removeRepo(repoId2, { from: repoRemover })
+        assert.isFalse(await app.isRepoAdded(repoId2), 'repo at in the middle of the array should have been removed')
+        assert.isTrue(await app.isRepoAdded(repoId3), 'repo3 should still be accessible')
+
+        repoId2 = addedRepo(
+          await app.addRepo(
+            'MDawOlJlcG9zaXRvcnk3NTM5NTIyNA==', // repoId
+            { from: owner1 }
+          )
+        )
+
+        await app.removeRepo(repoId, { from: repoRemover })
+        assert.isFalse(await app.isRepoAdded(repoId), 'repo at in the middle of the array should have been removed')
+        assert.isTrue(await app.isRepoAdded(repoId2), 'repo2 should still be accessible')
       })
 
       context('standard bounty verification tests', () => {


### PR DESCRIPTION
This solution is constant-time in that it ensures the index of the repo in question does not exceed the repoIndex array length before attempting to access it.

I also added 3 test cases with a repo array length of 3 to ensure correct behavior regardless of which array position is removed.