### PR TITLE
View Funding Proposal action button

### DIFF
--- a/apps/projects/app/components/Shared/BountyContextMenu.js
+++ b/apps/projects/app/components/Shared/BountyContextMenu.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
-import { ContextMenuItem } from '@aragon/ui'
+import styled, { css } from 'styled-components'
+import { ContextMenuItem, theme } from '@aragon/ui'
 
 const BountyContextMenu = ({
   work,
@@ -9,50 +9,66 @@ const BountyContextMenu = ({
   requestsData,
   onAllocateSingleBounty,
   onUpdateBounty,
+  onViewBounty,
   onSubmitWork,
   onRequestAssignment,
   onReviewApplication,
-  onReviewWork
-}) => <div>
-  {workStatus === undefined &&
-    <ContextMenuItem onClick={onAllocateSingleBounty}>
-      <ActionLabel>Fund Issue</ActionLabel>
-    </ContextMenuItem>
-  }
-  {workStatus === 'in-progress' &&
-    <ContextMenuItem onClick={onSubmitWork}>
-      <ActionLabel>Submit Work</ActionLabel>
-    </ContextMenuItem>
-  }
-  {workStatus === 'review-work' &&
-    <ContextMenuItem onClick={onReviewWork}>
-      <ActionLabel>Review Work</ActionLabel>
-    </ContextMenuItem>
-  }
-  {workStatus === 'funded' &&
-    <div>
-      <ContextMenuItem onClick={onUpdateBounty}>
-        <ActionLabel>Update Funding</ActionLabel>
-      </ContextMenuItem>
-      <ContextMenuItem onClick={onRequestAssignment}>
-        <ActionLabel>Request Assignment</ActionLabel>
-      </ContextMenuItem>
-    </div>
-  }
-  {workStatus === 'review-applicants' &&
-    <div>
-      <ContextMenuItem onClick={onUpdateBounty}>
-        <ActionLabel>Update Funding</ActionLabel>
-      </ContextMenuItem>
-      <ContextMenuItem onClick={onReviewApplication}>
-        <ActionLabel>Review Application ({requestsData.length})</ActionLabel>
-      </ContextMenuItem>
-    </div>
-  }
-</div>
+  onReviewWork,
+}) => (
+  <React.Fragment>
+    {workStatus === undefined && (
+      <Item onClick={onAllocateSingleBounty}>Fund Issue</Item>
+    )}
+    {workStatus === 'in-progress' && (
+      <React.Fragment>
+        <Item onClick={onSubmitWork}>Submit Work</Item>
+        <Item bordered onClick={onViewBounty}>
+          View Funding Proposal
+        </Item>
+      </React.Fragment>
+    )}
+    {workStatus === 'review-work' && (
+      <React.Fragment>
+        <Item onClick={onReviewWork}>Review Work</Item>
+        <Item bordered onClick={onViewBounty}>
+          View Funding Proposal
+        </Item>
+      </React.Fragment>
+    )}
+    {workStatus === 'funded' && (
+      <React.Fragment>
+        <Item onClick={onRequestAssignment}>Request Assignment</Item>
+        <Item bordered onClick={onUpdateBounty}>
+          Update Funding
+        </Item>
+        <Item onClick={onViewBounty}>View Funding Proposal</Item>
+      </React.Fragment>
+    )}
+    {workStatus === 'review-applicants' && (
+      <React.Fragment>
+        <Item onClick={onReviewApplication}>
+          Review Application ({requestsData.length})
+        </Item>
+        <Item bordered onClick={onUpdateBounty}>
+          Update Funding
+        </Item>
+        <Item onClick={onViewBounty}>View Funding Proposal</Item>
+      </React.Fragment>
+    )}
+    {workStatus === 'fulfilled' && (
+      <Item onClick={onViewBounty}>View Funding Proposal</Item>
+    )}
+  </React.Fragment>
+)
 
-const ActionLabel = styled.span`
-  margin-left: 15px;
+const Item = styled(ContextMenuItem)`
+  ${props =>
+    props.bordered &&
+    css`
+      border-top: 1px solid ${theme.shadow};
+      margin-top: 10px;
+      padding-top: 10px;
+    `};
 `
 
 BountyContextMenu.propTypes = {
@@ -62,11 +78,25 @@ BountyContextMenu.propTypes = {
   onReviewApplication: PropTypes.func.isRequired,
   onReviewWork: PropTypes.func.isRequired,
   onUpdateBounty: PropTypes.func.isRequired,
-  work: PropTypes.oneOf([
+  onViewBounty: PropTypes.func,
+  work: PropTypes.oneOf([ undefined, PropTypes.object ]),
+  workStatus: PropTypes.oneOf([
     undefined,
-    PropTypes.object,
+    'funded',
+    'review-applicants',
+    'in-progress',
+    'review-work',
+    'fulfilled',
   ]),
-  workStatus: PropTypes.oneOf([ undefined, 'funded', 'review-applicants', 'in-progress', 'review-work', 'fulfilled' ]),
+}
+
+BountyContextMenu.defaultProps = {
+  onViewBounty: () => {
+    console.log(
+      '%c "View Funding Proposal" is coming soon!',
+      `color: ${theme.accent}; font-size: 2em;`
+    )
+  },
 }
 
 export default BountyContextMenu


### PR DESCRIPTION
Fixes #934 

[Requirements]:

- [x] For issues which have been proposed for funding and have been proposed
      in the past, display a “View Funding Proposal” action in the issue’s
      context menu.

- [x] This “View Funding Proposal” action should also be displayed in
      the context meny of the Issue Detail page.

- [x] It should be displayed at all times, regardless of the bounty
      status (it sholuld be included for fulfilled bounties)

Other things that snuck into this change:

- Remove the `ActionLabel` component, which only added some spacing to
  the left of items. This spacing is no longer wanted.
- Create a new `Item` styled component which wraps `ContextMenuItem` and
  allows adding a `bordered` property which adds a top border. This
  border provides visual separation between groups of menu items.

  Here's an example of what this action menu looks like now:

  <img width="203" alt="Screen Shot 2019-05-30 at 14 27 24" src="https://user-images.githubusercontent.com/221614/58658933-b95a2c80-82ef-11e9-94e6-b29faacf2232.png">

- My `prettier` auto-runs on save, and reformatted some code (adding
  trailing commas and adjusting line lengths here andd there.)

You'll see that the `onViewBounty` function is not yet required, because
nothing else uses it yet. And you'll see that the default function uses
`console.log` with some loud formatting. I would have preferred to use
`alert`, but that is not allowed in an `iframe` by default, and fixing
that is out-of-scope of this change.

  [Requirements]: https://docs.google.com/document/d/1YErknw9EAjo3u-S7VdSXXMtPLfs7LLC8ly4Y7kVtEs0/edit