### PR TITLE
Add Funding Side Panel

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -344,6 +344,11 @@ class App extends React.PureComponent {
     this.props.api.requestAssignment(toHex(issue.repoId), issue.number, hash)
   }
 
+  viewFunding = issue => {
+    console.log('view funding for issue:')
+    console.table(issue)
+  }
+
   reviewApplication = (issue, requestIndex = 0) => {
     this.setState((_prevState, _prevProps) => ({
       panel: PANELS.ReviewApplication,
@@ -593,6 +598,7 @@ class App extends React.PureComponent {
                   onUpdateBounty={this.updateBounty}
                   onSubmitWork={this.submitWork}
                   onRequestAssignment={this.requestAssignment}
+                  onViewFunding={this.viewFunding}
                   activeIndex={activeIndex}
                   changeActiveIndex={this.changeActiveIndex}
                   onReviewApplication={this.reviewApplication}

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -374,6 +374,7 @@ class App extends React.PureComponent {
       panelProps: {
         fundingProposal,
         title: `Issue Funding #${fundingProposal.id}`,
+        tokens: this.props.tokens || [],
       },
     }))
   }

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -345,8 +345,14 @@ class App extends React.PureComponent {
   }
 
   viewFunding = issue => {
-    console.log('view funding for issue:')
-    console.table(issue)
+    this.setState((_prevState, _prevProps) => ({
+      panel: PANELS.ViewFunding,
+      panelProps: {
+        issue,
+        title: `Issue Funding #${issue.number}`,
+        githubCurrentUser: this.state.githubCurrentUser,
+      },
+    }))
   }
 
   reviewApplication = (issue, requestIndex = 0) => {

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -345,12 +345,35 @@ class App extends React.PureComponent {
   }
 
   viewFunding = issue => {
+    const fundingProposal = {
+      id: 'Unknown', // FIXME: how to retrieve this?
+      description:
+        'Funding Request cannot be retrieved at this time; this feature will be completed soon.', // FIXME: how to retrieve this?
+      createdBy: issue.fundingHistory[0].user, // FIXME: does not contain Eth address; how to retrieve it?
+      issues: this.props.issues
+        .filter(
+          i => i.data.key === issue.id // FIXME: what attribute links issues from the same funding event?
+        )
+        .map(i => ({
+          balance: i.data.balance,
+          exp: i.data.exp,
+          deadline: i.data.deadline,
+          hours: i.data.hours,
+          number: i.data.number,
+          repo: i.data.repo,
+          title:
+            i.data.title ||
+            'Issue list cannot be retrieved at this time; this feature will be completed soon.', // FIXME: this attr is in `issue` returned from Issues.js, but not in this.props.issues
+          tokenSymbol: tokens[i.data.token].symbol,
+          url: i.data.url || 'https://github.com/404', // FIXME: this attr is in `issue` returned from Issues.js, but not in this.props.issues
+          workStatus: i.data.workStatus,
+        })),
+    }
     this.setState((_prevState, _prevProps) => ({
       panel: PANELS.ViewFunding,
       panelProps: {
-        issue,
-        title: `Issue Funding #${issue.number}`,
-        githubCurrentUser: this.state.githubCurrentUser,
+        fundingProposal,
+        title: `Issue Funding #${fundingProposal.id}`,
       },
     }))
   }

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -345,6 +345,14 @@ class App extends React.PureComponent {
   }
 
   viewFunding = issue => {
+    const tokens = this.props.tokens.reduce((tokenObj, token) => {
+      tokenObj[token.addr] = {
+        symbol: token.symbol,
+        decimals: token.decimals,
+      }
+      return tokenObj
+    }, {})
+
     const fundingProposal = {
       id: 'Unknown', // FIXME: how to retrieve this?
       description:
@@ -355,8 +363,10 @@ class App extends React.PureComponent {
           i => i.data.key === issue.id // FIXME: what attribute links issues from the same funding event?
         )
         .map(i => ({
-          balance: i.data.balance,
-          exp: i.data.exp,
+          balance: BigNumber(i.data.balance).div(
+            BigNumber(10 ** tokens[i.data.token].decimals)
+          ),
+          expLevel: this.props.bountySettings.expLvls[i.data.exp].name,
           deadline: i.data.deadline,
           hours: i.data.hours,
           number: i.data.number,
@@ -374,7 +384,6 @@ class App extends React.PureComponent {
       panelProps: {
         fundingProposal,
         title: `Issue Funding #${fundingProposal.id}`,
-        tokens: this.props.tokens || [],
       },
     }))
   }

--- a/apps/projects/app/components/Card/Issue.js
+++ b/apps/projects/app/components/Card/Issue.js
@@ -2,13 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
-import {
-  Text,
-  theme,
-  Badge,
-  Checkbox,
-  ContextMenu,
-} from '@aragon/ui'
+import { Text, theme, Badge, Checkbox, ContextMenu } from '@aragon/ui'
 
 import { formatDistance } from 'date-fns'
 import { BountyContextMenu } from '../Shared'
@@ -46,7 +40,6 @@ const labelsBadges = labels =>
   ))
 
 class Issue extends React.PureComponent {
-
   render() {
     const {
       isSelected,
@@ -57,6 +50,7 @@ class Issue extends React.PureComponent {
       onReviewApplication,
       onAllocateSingleBounty,
       onUpdateBounty,
+      onViewFunding,
       onReviewWork,
       ...issue
     } = this.props
@@ -97,6 +91,7 @@ class Issue extends React.PureComponent {
                 onReviewWork={() => onReviewWork(issue)}
                 onSubmitWork={() => onSubmitWork(issue)}
                 onUpdateBounty={() => onUpdateBounty(issue)}
+                onViewFunding={() => onViewFunding(issue)}
                 requestsData={requestsData}
                 work={work}
                 workStatus={workStatus}
@@ -105,16 +100,19 @@ class Issue extends React.PureComponent {
           </div>
           <IssueTitleDetailsBalance>
             <IssueTitleDetails>
-              <IssueTitle>
-                {title}
-              </IssueTitle>
+              <IssueTitle>{title}</IssueTitle>
 
-              {(BOUNTY_STATUS[workStatus]) && (
-                <Text.Block color={theme.textSecondary} style={{ fontSize: '0.87em' }}>
+              {BOUNTY_STATUS[workStatus] && (
+                <Text.Block
+                  color={theme.textSecondary}
+                  style={{ fontSize: '0.87em' }}
+                >
                   <span style={{ marginRight: '15px' }}>
                     {expLevel}
                     {dot}
-                    {balance > 0 ? BOUNTY_STATUS[workStatus] : BOUNTY_STATUS['fulfilled']}
+                    {balance > 0
+                      ? BOUNTY_STATUS[workStatus]
+                      : BOUNTY_STATUS['fulfilled']}
                     {dot}
                     Due {DeadlineDistance(deadline)}
                   </span>
@@ -123,21 +121,19 @@ class Issue extends React.PureComponent {
             </IssueTitleDetails>
 
             <Balance>
-              {(BOUNTY_STATUS[workStatus]) && (
+              {BOUNTY_STATUS[workStatus] && (
                 <Badge
                   style={{ padding: '10px' }}
                   background={BOUNTY_BADGE_COLOR[workStatus].bg}
                   foreground={BOUNTY_BADGE_COLOR[workStatus].fg}
                 >
-                  <Text>
-                    {balance + ' ' + symbol}
-                  </Text>
+                  <Text>{balance + ' ' + symbol}</Text>
                 </Badge>
               )}
             </Balance>
           </IssueTitleDetailsBalance>
 
-          {(labels.totalCount > 0) && (
+          {labels.totalCount > 0 && (
             <div>
               <Separator />
               {labelsBadges(labels)}
@@ -161,12 +157,17 @@ Issue.propTypes = {
   onReviewApplication: PropTypes.func.isRequired,
   onAllocateSingleBounty: PropTypes.func.isRequired,
   onUpdateBounty: PropTypes.func.isRequired,
+  onViewFunding: PropTypes.func.isRequired,
   onReviewWork: PropTypes.func.isRequired,
-  workStatus: PropTypes.oneOf([ undefined, 'funded', 'review-applicants', 'in-progress', 'review-work', 'fulfilled' ]),
-  work: PropTypes.oneOf([
+  workStatus: PropTypes.oneOf([
     undefined,
-    PropTypes.object,
+    'funded',
+    'review-applicants',
+    'in-progress',
+    'review-work',
+    'fulfilled',
   ]),
+  work: PropTypes.oneOf([ undefined, PropTypes.object ]),
 }
 
 const StyledIssue = styled.div`

--- a/apps/projects/app/components/Card/Issue.js
+++ b/apps/projects/app/components/Card/Issue.js
@@ -44,9 +44,9 @@ const labelsBadges = labels =>
       {label.node.name}
     </Badge>
   ))
- 
+
 class Issue extends React.PureComponent {
- 
+
   render() {
     const {
       isSelected,
@@ -92,15 +92,15 @@ class Issue extends React.PureComponent {
             {workStatus !== 'fulfilled' && (
               <ContextMenu>
                 <BountyContextMenu
-                  work={work}
-                  workStatus={workStatus}
-                  requestsData={requestsData}
                   onAllocateSingleBounty={() => onAllocateSingleBounty(issue)}
-                  onSubmitWork={() => onSubmitWork(issue)}
                   onRequestAssignment={() => onRequestAssignment(issue)}
                   onReviewApplication={() => onReviewApplication(issue)}
                   onReviewWork={() => onReviewWork(issue)}
+                  onSubmitWork={() => onSubmitWork(issue)}
                   onUpdateBounty={() => onUpdateBounty(issue)}
+                  requestsData={requestsData}
+                  work={work}
+                  workStatus={workStatus}
                 />
               </ContextMenu>
             )}
@@ -171,7 +171,7 @@ Issue.propTypes = {
     PropTypes.object,
   ]),
 }
-  
+
 const StyledIssue = styled.div`
   flex: 1;
   width: 100%;

--- a/apps/projects/app/components/Card/Issue.js
+++ b/apps/projects/app/components/Card/Issue.js
@@ -89,22 +89,19 @@ class Issue extends React.PureComponent {
             <Text color={theme.textSecondary} size="xsmall">
               {repo} #{number}
             </Text>
-            {workStatus !== 'fulfilled' && (
-              <ContextMenu>
-                <BountyContextMenu
-                  onAllocateSingleBounty={() => onAllocateSingleBounty(issue)}
-                  onRequestAssignment={() => onRequestAssignment(issue)}
-                  onReviewApplication={() => onReviewApplication(issue)}
-                  onReviewWork={() => onReviewWork(issue)}
-                  onSubmitWork={() => onSubmitWork(issue)}
-                  onUpdateBounty={() => onUpdateBounty(issue)}
-                  requestsData={requestsData}
-                  work={work}
-                  workStatus={workStatus}
-                />
-              </ContextMenu>
-            )}
-
+            <ContextMenu>
+              <BountyContextMenu
+                onAllocateSingleBounty={() => onAllocateSingleBounty(issue)}
+                onRequestAssignment={() => onRequestAssignment(issue)}
+                onReviewApplication={() => onReviewApplication(issue)}
+                onReviewWork={() => onReviewWork(issue)}
+                onSubmitWork={() => onSubmitWork(issue)}
+                onUpdateBounty={() => onUpdateBounty(issue)}
+                requestsData={requestsData}
+                work={work}
+                workStatus={workStatus}
+              />
+            </ContextMenu>
           </div>
           <IssueTitleDetailsBalance>
             <IssueTitleDetails>

--- a/apps/projects/app/components/Content/IssueDetail/IssueDetail.js
+++ b/apps/projects/app/components/Content/IssueDetail/IssueDetail.js
@@ -244,6 +244,7 @@ const detailsCard = ({
   onReviewApplication,
   onReviewWork,
   onUpdateBounty,
+  onViewFunding,
   onRequestAssignment,
   onSubmitWork,
   onAllocateSingleBounty,
@@ -295,6 +296,7 @@ const detailsCard = ({
               onReviewWork={() => onReviewWork(issue)}
               onSubmitWork={() => onSubmitWork(issue)}
               onUpdateBounty={() => onUpdateBounty(issue)}
+              onViewFunding={() => onViewFunding(issue)}
               requestsData={issue.requestsData}
               work={issue.work}
               workStatus={issue.workStatus}
@@ -413,6 +415,8 @@ IssueDetail.propTypes = {
   onRequestAssignment: PropTypes.func.isRequired,
   onReviewApplication: PropTypes.func.isRequired,
   onReviewWork: PropTypes.func.isRequired,
+  onUpdateBounty: PropTypes.func.isRequired,
+  onViewFunding: PropTypes.func.isRequired,
   workStatus: PropTypes.oneOf([
     undefined,
     'funded',

--- a/apps/projects/app/components/Content/IssueDetail/IssueDetail.js
+++ b/apps/projects/app/components/Content/IssueDetail/IssueDetail.js
@@ -287,21 +287,19 @@ const detailsCard = ({
           </Text.Block>
         </div>
         <div style={{ ...column, flex: 0, alignItems: 'flex-end' }}>
-          {issue.workStatus !== 'fulfilled' && (
-            <ContextMenu>
-              <BountyContextMenu
-                onAllocateSingleBounty={() => onAllocateSingleBounty(issue)}
-                onRequestAssignment={() => onRequestAssignment(issue)}
-                onReviewApplication={() => onReviewApplication(issue)}
-                onReviewWork={() => onReviewWork(issue)}
-                onSubmitWork={() => onSubmitWork(issue)}
-                onUpdateBounty={() => onUpdateBounty(issue)}
-                requestsData={issue.requestsData}
-                work={issue.work}
-                workStatus={issue.workStatus}
-              />
-            </ContextMenu>
-          )}
+          <ContextMenu>
+            <BountyContextMenu
+              onAllocateSingleBounty={() => onAllocateSingleBounty(issue)}
+              onRequestAssignment={() => onRequestAssignment(issue)}
+              onReviewApplication={() => onReviewApplication(issue)}
+              onReviewWork={() => onReviewWork(issue)}
+              onSubmitWork={() => onSubmitWork(issue)}
+              onUpdateBounty={() => onUpdateBounty(issue)}
+              requestsData={issue.requestsData}
+              work={issue.work}
+              workStatus={issue.workStatus}
+            />
+          </ContextMenu>
           {issue.balance > 0 && (
             <Badge
               style={{ padding: '10px', textSize: 'large', marginTop: '15px' }}

--- a/apps/projects/app/components/Content/IssueDetail/IssueDetail.js
+++ b/apps/projects/app/components/Content/IssueDetail/IssueDetail.js
@@ -290,15 +290,15 @@ const detailsCard = ({
           {issue.workStatus !== 'fulfilled' && (
             <ContextMenu>
               <BountyContextMenu
-                work={issue.work}
-                workStatus={issue.workStatus}
-                requestsData={issue.requestsData}
-                onUpdateBounty={() => onUpdateBounty(issue)}
                 onAllocateSingleBounty={() => onAllocateSingleBounty(issue)}
-                onSubmitWork={() => onSubmitWork(issue)}
                 onRequestAssignment={() => onRequestAssignment(issue)}
                 onReviewApplication={() => onReviewApplication(issue)}
                 onReviewWork={() => onReviewWork(issue)}
+                onSubmitWork={() => onSubmitWork(issue)}
+                onUpdateBounty={() => onUpdateBounty(issue)}
+                requestsData={issue.requestsData}
+                work={issue.work}
+                workStatus={issue.workStatus}
               />
             </ContextMenu>
           )}

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -35,6 +35,13 @@ class Issues extends React.PureComponent {
       event: PropTypes.string,
     }),
     issueDetail: PropTypes.bool.isRequired,
+    onAllocateBounties: PropTypes.func.isRequired,
+    onRequestAssignment: PropTypes.func.isRequired,
+    onReviewApplication: PropTypes.func.isRequired,
+    onReviewWork: PropTypes.func.isRequired,
+    onSubmitWork: PropTypes.func.isRequired,
+    onUpdateBounty: PropTypes.func.isRequired,
+    onViewFunding: PropTypes.func.isRequired,
     setIssueDetail: PropTypes.func.isRequired,
   }
 
@@ -404,6 +411,7 @@ class Issues extends React.PureComponent {
       onReviewApplication,
       onSubmitWork,
       onReviewWork,
+      onViewFunding,
     } = this.props
 
     currentIssue.repository = {
@@ -422,6 +430,7 @@ class Issues extends React.PureComponent {
         onSubmitWork={onSubmitWork}
         onAllocateSingleBounty={this.handleAllocateSingleBounty}
         onUpdateBounty={this.handleUpdateBounty}
+        onViewFunding={onViewFunding}
         onReviewWork={onReviewWork}
       />
     )
@@ -484,6 +493,7 @@ class Issues extends React.PureComponent {
       onReviewApplication,
       onSubmitWork,
       onReviewWork,
+      onViewFunding,
       issueDetail,
     } = this.props
 
@@ -573,6 +583,7 @@ class Issues extends React.PureComponent {
                               this.handleAllocateSingleBounty
                             }
                             onUpdateBounty={this.handleUpdateBounty}
+                            onViewFunding={onViewFunding}
                             onReviewWork={onReviewWork}
                           />
                         )

--- a/apps/projects/app/components/Panel/PanelManager.js
+++ b/apps/projects/app/components/Panel/PanelManager.js
@@ -16,6 +16,7 @@ const dynamicImport = Object.freeze({
   ReviewApplication: () => import('./ReviewApplication'),
   ReviewWork: () => import('./ReviewWork'),
   SubmitWork: () => import('./SubmitWork'),
+  ViewFunding: () => import('./ViewFunding'),
 })
 
 const PANELS = Object.keys(dynamicImport).reduce((obj, item) => {
@@ -24,7 +25,9 @@ const PANELS = Object.keys(dynamicImport).reduce((obj, item) => {
 }, {})
 
 const PanelManager = ({ activePanel = null, onClose, ...panelProps }) => {
-  const panelTitle = panelProps.title ? panelProps.title : activePanel && camel2title(activePanel)
+  const panelTitle = panelProps.title
+    ? panelProps.title
+    : activePanel && camel2title(activePanel)
   const PanelComponent = activePanel && React.lazy(dynamicImport[activePanel])
   return (
     <SidePanel

--- a/apps/projects/app/components/Panel/ViewFunding/Issue.js
+++ b/apps/projects/app/components/Panel/ViewFunding/Issue.js
@@ -1,0 +1,112 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Badge, Text, theme } from '@aragon/ui'
+import { formatDistance } from 'date-fns'
+import BigNumber from 'bignumber.js'
+
+import { BOUNTY_STATUS, BOUNTY_BADGE_COLOR } from '../../../utils/bounty-status'
+
+export const issueShape = PropTypes.shape({
+  balance: PropTypes.instanceOf(BigNumber).isRequired,
+  expLevel: PropTypes.string.isRequired,
+  deadline: PropTypes.string.isRequired,
+  hours: PropTypes.number.isRequired,
+  number: PropTypes.number.isRequired,
+  repo: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  tokenSymbol: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  workStatus: PropTypes.string.isRequired,
+})
+
+const Issue = ({
+  balance,
+  expLevel,
+  deadline,
+  hours,
+  number,
+  repo,
+  tokenSymbol,
+  title,
+  url,
+  workStatus,
+}) => (
+  <Wrap>
+    <Left>
+      <Text.Block color={theme.textSecondary} size="small">
+        {repo} #{number}
+      </Text.Block>
+      <Title>{title}</Title>
+      <Details>
+        <span>{hours} hours</span>
+        <Dot />
+        <span>{expLevel}</span>
+        <Dot />
+        <span>
+          Due{' '}
+          {formatDistance(new Date(deadline), new Date(), { addSuffix: true })}
+        </span>
+      </Details>
+    </Left>
+    <Right>
+      {BOUNTY_STATUS[workStatus] && (
+        <Badge
+          style={{ padding: '10px' }}
+          background={BOUNTY_BADGE_COLOR[workStatus].bg}
+          foreground={BOUNTY_BADGE_COLOR[workStatus].fg}
+        >
+          {balance.dp(3).toString() + ' ' + tokenSymbol}
+        </Badge>
+      )}
+    </Right>
+  </Wrap>
+)
+
+Issue.propTypes = issueShape.isRequired
+
+const Wrap = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  margin-left: -1em;
+  margin-top: -7px;
+  > * {
+    margin-left: 1em;
+    margin-top: 7px;
+  }
+`
+const Left = styled.div`
+  flex: 1;
+`
+const Right = styled.div`
+  flex: 0 0 1px;
+`
+const Title = styled(Text.Block)`
+  margin: 5px 0 7px;
+`
+const Details = styled(Text.Block).attrs({
+  color: theme.textTertiary,
+  size: 'xsmall',
+})`
+  white-space: nowrap;
+`
+
+// Ensures screen readers don't smash adjacent items together
+const Spacer = props => <span {...props}> </span>
+
+// Adds extra visual distinction to Spacer with a glyph that is:
+//   * ignored by screen readers
+//   * not selected when selecting surrounding text for copy/paste
+export const Dot = styled(Spacer).attrs({
+  'aria-hidden': true,
+})`
+  :before {
+    content: '·';
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+`
+
+export default Issue

--- a/apps/projects/app/components/Panel/ViewFunding/ViewFunding.js
+++ b/apps/projects/app/components/Panel/ViewFunding/ViewFunding.js
@@ -6,19 +6,36 @@ import { Text, theme } from '@aragon/ui'
 
 class ViewFunding extends React.Component {
   static propTypes = {
-    issue: PropTypes.shape({
-      title: PropTypes.string.isRequired,
-    }).isRequired,
+    fundingProposal: PropTypes.shape({
+      description: PropTypes.string.isRequired,
+      createdBy: PropTypes.shape({
+        avatarUrl: PropTypes.string.isRequired,
+        login: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+      }).isRequired,
+      issues: PropTypes.arrayOf(
+        PropTypes.shape({
+          balance: PropTypes.string.isRequired,
+          exp: PropTypes.number.isRequired,
+          deadline: PropTypes.string.isRequired,
+          hours: PropTypes.number.isRequired,
+          number: PropTypes.number.isRequired,
+          repo: PropTypes.string.isRequired,
+          title: PropTypes.string.isRequired,
+          token: PropTypes.string.isRequired,
+          url: PropTypes.string.isRequired,
+          workStatus: PropTypes.string.isRequired,
+        })
+      ).isRequired,
+    }),
   }
 
   render() {
-    const { issue } = this.props
-
-    console.log({ component: 'ViewFunding', issue })
+    const { description } = this.props.fundingProposal
 
     return (
       <React.Fragment>
-        <IssueTitle>{issue.title}</IssueTitle>
+        <IssueTitle>{description}</IssueTitle>
       </React.Fragment>
     )
   }

--- a/apps/projects/app/components/Panel/ViewFunding/ViewFunding.js
+++ b/apps/projects/app/components/Panel/ViewFunding/ViewFunding.js
@@ -2,51 +2,142 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
-import { Text, theme } from '@aragon/ui'
+import { IdentityBadge, Text, theme } from '@aragon/ui'
+import BigNumber from 'bignumber.js'
 
-class ViewFunding extends React.Component {
-  static propTypes = {
-    fundingProposal: PropTypes.shape({
-      description: PropTypes.string.isRequired,
-      createdBy: PropTypes.shape({
-        avatarUrl: PropTypes.string.isRequired,
-        login: PropTypes.string.isRequired,
-        url: PropTypes.string.isRequired,
-      }).isRequired,
-      issues: PropTypes.arrayOf(
-        PropTypes.shape({
-          balance: PropTypes.string.isRequired,
-          exp: PropTypes.number.isRequired,
-          deadline: PropTypes.string.isRequired,
-          hours: PropTypes.number.isRequired,
-          number: PropTypes.number.isRequired,
-          repo: PropTypes.string.isRequired,
-          title: PropTypes.string.isRequired,
-          token: PropTypes.string.isRequired,
-          url: PropTypes.string.isRequired,
-          workStatus: PropTypes.string.isRequired,
-        })
-      ).isRequired,
-    }),
-  }
+const issueShape = PropTypes.shape({
+  balance: PropTypes.string.isRequired,
+  exp: PropTypes.number.isRequired,
+  deadline: PropTypes.string.isRequired,
+  hours: PropTypes.number.isRequired,
+  number: PropTypes.number.isRequired,
+  repo: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  token: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  workStatus: PropTypes.string.isRequired,
+})
 
-  render() {
-    const { description } = this.props.fundingProposal
+const Issue = ({
+  balance,
+  exp,
+  deadline,
+  hours,
+  number,
+  repo,
+  title,
+  token,
+  url,
+  workStatus,
+}) => (
+  <React.Fragment>
+    {repo} #{number}
+    {title}
+    {hours} hours
+    {exp}
+    {deadline}
+    {balance}
+  </React.Fragment>
+)
 
-    return (
-      <React.Fragment>
-        <IssueTitle>{description}</IssueTitle>
-      </React.Fragment>
-    )
-  }
+Issue.propTypes = issueShape.isRequired
+
+const calcTotalFunding = ({ issues, tokens }) => {
+  const balancesByToken = issues.reduce((group, issue) => {
+    group[issue.token] = (group[issue.token] || 0) + Number(issue.balance)
+    return group
+  }, {})
+
+  const totals = Object.keys(balancesByToken).map(tokenAddr => {
+    const token = tokens.find(t => t.addr === tokenAddr)
+
+    const total = BigNumber(balancesByToken[tokenAddr])
+      .div(BigNumber(10 ** token.decimals))
+      .dp(3)
+      .toString()
+
+    return `${total} ${token.symbol}`
+  })
+
+  return totals
 }
 
-const IssueTitle = styled(Text)`
-  color: ${theme.textSecondary};
-  font-size: 17px;
-  font-weight: 300;
-  line-height: 1.5;
-  margin-bottom: 10px;
+const ViewFunding = ({
+  fundingProposal: { createdBy, description, issues },
+  tokens,
+}) => (
+  <Grid>
+    <Half>
+      <Label>Created By</Label>
+      <IdentityBadge entity={createdBy.login} />
+    </Half>
+    <Half>
+      <Label>Status</Label>
+      {issues[0].workStatus}
+    </Half>
+    <Full>
+      <Label>Description</Label>
+      {description}
+    </Full>
+    <Half>
+      <Label>Total Funding</Label>
+      {calcTotalFunding({ issues, tokens }).join(' • ')}
+    </Half>
+    <Half>
+      <Label>Total Issues</Label>
+      {issues.length}
+    </Half>
+    {issues.map(issue => (
+      <Full key={issue.number}>
+        <Issue key={issue.number} {...issue} />
+      </Full>
+    ))}
+  </Grid>
+)
+
+ViewFunding.propTypes = {
+  fundingProposal: PropTypes.shape({
+    description: PropTypes.string.isRequired,
+    createdBy: PropTypes.shape({
+      avatarUrl: PropTypes.string.isRequired,
+      login: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    }).isRequired,
+    issues: PropTypes.arrayOf(issueShape).isRequired,
+  }),
+  tokens: PropTypes.arrayOf(
+    PropTypes.shape({
+      addr: PropTypes.string.isRequired,
+      decimals: PropTypes.string.isRequired,
+      symbol: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+}
+
+const Grid = styled.div`
+  background: ${theme.contentBorder};
+  display: grid;
+  grid-gap: 1px;
+  grid-template-columns: 50% 50%;
+  margin: 0 -30px;
+  padding-top: 1px;
+  > * {
+    background: white;
+    padding: 30px;
+  }
+`
+const Half = styled.div`
+  grid-column: span 1;
+`
+const Full = styled.div`
+  grid-column: span 2;
+`
+const Label = styled(Text.Block).attrs({
+  size: 'small',
+  color: theme.textTertiary,
+})`
+  margin-bottom: 15px;
+  text-transform: uppercase;
 `
 
 export default ViewFunding

--- a/apps/projects/app/components/Panel/ViewFunding/ViewFunding.js
+++ b/apps/projects/app/components/Panel/ViewFunding/ViewFunding.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Text, theme } from '@aragon/ui'
+
+class ViewFunding extends React.Component {
+  static propTypes = {
+    issue: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+    }).isRequired,
+  }
+
+  render() {
+    const { issue } = this.props
+
+    console.log({ component: 'ViewFunding', issue })
+
+    return (
+      <React.Fragment>
+        <IssueTitle>{issue.title}</IssueTitle>
+      </React.Fragment>
+    )
+  }
+}
+
+const IssueTitle = styled(Text)`
+  color: ${theme.textSecondary};
+  font-size: 17px;
+  font-weight: 300;
+  line-height: 1.5;
+  margin-bottom: 10px;
+`
+
+export default ViewFunding

--- a/apps/projects/app/components/Panel/ViewFunding/index.js
+++ b/apps/projects/app/components/Panel/ViewFunding/index.js
@@ -1,0 +1,1 @@
+export { default } from './ViewFunding'

--- a/apps/projects/app/components/Shared/BountyContextMenu.js
+++ b/apps/projects/app/components/Shared/BountyContextMenu.js
@@ -9,7 +9,7 @@ const BountyContextMenu = ({
   requestsData,
   onAllocateSingleBounty,
   onUpdateBounty,
-  onViewBounty,
+  onViewFunding,
   onSubmitWork,
   onRequestAssignment,
   onReviewApplication,
@@ -22,7 +22,7 @@ const BountyContextMenu = ({
     {workStatus === 'in-progress' && (
       <React.Fragment>
         <Item onClick={onSubmitWork}>Submit Work</Item>
-        <Item bordered onClick={onViewBounty}>
+        <Item bordered onClick={onViewFunding}>
           View Funding Proposal
         </Item>
       </React.Fragment>
@@ -30,7 +30,7 @@ const BountyContextMenu = ({
     {workStatus === 'review-work' && (
       <React.Fragment>
         <Item onClick={onReviewWork}>Review Work</Item>
-        <Item bordered onClick={onViewBounty}>
+        <Item bordered onClick={onViewFunding}>
           View Funding Proposal
         </Item>
       </React.Fragment>
@@ -41,7 +41,7 @@ const BountyContextMenu = ({
         <Item bordered onClick={onUpdateBounty}>
           Update Funding
         </Item>
-        <Item onClick={onViewBounty}>View Funding Proposal</Item>
+        <Item onClick={onViewFunding}>View Funding Proposal</Item>
       </React.Fragment>
     )}
     {workStatus === 'review-applicants' && (
@@ -52,11 +52,11 @@ const BountyContextMenu = ({
         <Item bordered onClick={onUpdateBounty}>
           Update Funding
         </Item>
-        <Item onClick={onViewBounty}>View Funding Proposal</Item>
+        <Item onClick={onViewFunding}>View Funding Proposal</Item>
       </React.Fragment>
     )}
     {workStatus === 'fulfilled' && (
-      <Item onClick={onViewBounty}>View Funding Proposal</Item>
+      <Item onClick={onViewFunding}>View Funding Proposal</Item>
     )}
   </React.Fragment>
 )
@@ -78,7 +78,7 @@ BountyContextMenu.propTypes = {
   onReviewApplication: PropTypes.func.isRequired,
   onReviewWork: PropTypes.func.isRequired,
   onUpdateBounty: PropTypes.func.isRequired,
-  onViewBounty: PropTypes.func,
+  onViewFunding: PropTypes.func.isRequired,
   work: PropTypes.oneOf([ undefined, PropTypes.object ]),
   workStatus: PropTypes.oneOf([
     undefined,
@@ -88,15 +88,6 @@ BountyContextMenu.propTypes = {
     'review-work',
     'fulfilled',
   ]),
-}
-
-BountyContextMenu.defaultProps = {
-  onViewBounty: () => {
-    console.log(
-      '%c "View Funding Proposal" is coming soon!',
-      `color: ${theme.accent}; font-size: 2em;`
-    )
-  },
 }
 
 export default BountyContextMenu


### PR DESCRIPTION
Fixes https://github.com/AutarkLabs/planning-suite/issues/931

When viewing a funding proposal,

- [x] display a side panel

This panel must have the following details (see design mockup below):

- [x] A title that says: Issue Funding # <Proposal Numer>
- [x] Created By
- [x] ~Time Remaining (if Open)~ _From @stellarmagnet: "Don’t worry about time remaining for now, it will be conditionally displayed yet it’s dependent on some api work. I’d just default to displaying the status"_
- [x] Status (if Closed) - follow the same formatting as Dot Voting app
  - Approved
  - Rejected
- [x] Description
- [x] Total Funding
  - If there are multiple currencies, have a dot between them and list in alphabetical order and up to 2 decimal places
    - 400 ANT  •  50 DAI  •  0.23 ETH
- [x] Total Issues
  - The number of issues being funded
- [x] A list of each issue
  - Repo name
  - issue number
  - Issue name
  - Estimated time
  - Experience level
  - Deadline
  - “Due in…” - follow same format as Projects Issue List
  - Funding Amount

## Design Mockup

From https://projects.invisionapp.com/d/main#/console/17635937/365601746/preview

<img width="359" alt="Screen Shot 2019-06-04 at 16 03 53" src="https://user-images.githubusercontent.com/221614/58909977-68c54380-86e2-11e9-8b01-b1b1c7fde98e.png">
