### PR TITLE
Projects: Search exact text, not regex

### DIFF
--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -188,8 +188,8 @@ class Issues extends React.PureComponent {
     if (textFilter) {
       return issuesByStatus.filter(
         issue =>
-          issue.title.toUpperCase().match(textFilter) ||
-          String(issue.number).match(textFilter)
+          issue.title.toUpperCase().indexOf(textFilter) !== -1 ||
+          String(issue.number).indexOf(textFilter) !== -1
       )
     }
 


### PR DESCRIPTION
Fixes #901

This matches the behavior of GitHub, searching for exact strings rather than using regex. This means that searching for `*` will only match issues that actually have a `*` character in their title, rather than trying to construct an invalid regex (which caused an error, previously).