### PR TITLE
Added test dependencies

### DIFF
--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -50,11 +50,11 @@
     "styled-components": "4.1.3"
   },
   "devDependencies": {
-    "@tps/test-helpers": "^0.0.1",
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
+    "@tps/test-helpers": "^0.0.1",
     "babel-eslint": "^10.0.1",
     "babel-plugin-styled-components": "^1.10.0",
     "eslint": "^5.16.0",
@@ -67,13 +67,15 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-standard": "^4.0.0",
+    "ganache-cli": "^6.1.8",
     "parcel-bundler": "1.12.3",
     "prettier": "^1.17.1",
     "react-hot-loader": "^4.8.8",
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.3.0",
     "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.7.0"
+    "stylelint-processor-styled-components": "^1.7.0",
+    "truffle": "^4.1.14"
   },
   "author": "",
   "repository": {


### PR DESCRIPTION
I'm not sure why, but `npm run test` works when you want to run tests for all apps, but when you want to run tests only for the projects app, you `cd apps/projects` and then `npm run test` fails. This solves that.