### PR TITLE
Projects: improve useGithubAuth hook

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -27,7 +27,7 @@ import {
   REQUESTED_GITHUB_TOKEN_FAILURE,
 } from './store/eventTypes'
 
-import useGithubAuth from './hooks/useGithubAuth'
+import { initApolloClient } from './utils/apollo-client'
 import { getToken, getURLParam, githubPopup, STATUS } from './utils/github'
 
 const ASSETS_URL = './aragon-ui'
@@ -281,7 +281,7 @@ class App extends React.PureComponent {
 
 export default () => {
   const { api, appState, displayMenuButton } = useAragonApi()
-  const { client } = useGithubAuth()
+  const client = initApolloClient(appState.github && appState.github.token)
   return (
     <App
       api={api}

--- a/apps/projects/app/components/Content/Settings.js
+++ b/apps/projects/app/components/Content/Settings.js
@@ -391,7 +391,7 @@ const BaseRate = ({
 )
 
 const GitHubConnect = ({ onLogin, onLogout, status }) => {
-  const { githubCurrentUser: { login: user } } = useGithubAuth()
+  const { login: user } = useGithubAuth()
   const auth = status === STATUS.AUTHENTICATED
   const bodyText = auth ? (
     <span>

--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -529,7 +529,7 @@ const submitBountyAllocation = ({
 // TODO: move entire component to functional component
 // the following was a quick way to allow us to use hooks
 const FundIssuesWrap = props => {
-  const { githubCurrentUser } = useGithubAuth()
+  const githubCurrentUser = useGithubAuth()
   const {
     api,
     appState: { bountySettings, tokens },

--- a/apps/projects/app/components/Panel/RequestAssignment/RequestAssignment.js
+++ b/apps/projects/app/components/Panel/RequestAssignment/RequestAssignment.js
@@ -156,7 +156,7 @@ const onRequestAssignment = ({ closePanel, requestAssignment }) => async (
 // TODO: move entire component to functional component
 // the following was a quick way to allow us to use hooks
 const RequestAssignmentWrap = props => {
-  const { githubCurrentUser } = useGithubAuth()
+  const githubCurrentUser = useGithubAuth()
   const { api } = useAragonApi()
   const { closePanel } = usePanelManagement()
   return (

--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -234,7 +234,7 @@ const onReviewApplication = ({ closePanel, reviewApplication }) => async (
 // TODO: move entire component to functional component
 // the following was a quick way to allow us to use hooks
 const ReviewApplicationWrap = props => {
-  const { githubCurrentUser } = useGithubAuth()
+  const githubCurrentUser = useGithubAuth()
   const {
     api: { reviewApplication },
   } = useAragonApi()

--- a/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
+++ b/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
@@ -249,7 +249,7 @@ const onReviewWork = ({ closePanel, reviewSubmission }) => async (
 // TODO: move entire component to functional component
 // the following was a quick way to allow us to use hooks
 const ReviewWorkWrap = props => {
-  const { githubCurrentUser } = useGithubAuth()
+  const githubCurrentUser = useGithubAuth()
   const {
     api: { reviewSubmission },
   } = useAragonApi()

--- a/apps/projects/app/components/Panel/SubmitWork/SubmitWork.js
+++ b/apps/projects/app/components/Panel/SubmitWork/SubmitWork.js
@@ -159,7 +159,7 @@ const onSubmitWork = ({ closePanel, submitWork }) => async (state, issue) => {
 // TODO: move entire component to functional component
 // the following was a quick way to allow us to use hooks
 const SubmitWorkWrap = props => {
-  const { githubCurrentUser } = useGithubAuth()
+  const githubCurrentUser = useGithubAuth()
   const { closePanel } = usePanelManagement()
   const {
     api: { submitWork }

--- a/apps/projects/app/hooks/useGithubAuth.js
+++ b/apps/projects/app/hooks/useGithubAuth.js
@@ -8,16 +8,16 @@ const useGithubAuth = () => {
   const token = appState.github && appState.github.token
 
   const [ githubCurrentUser, setGithubCurrentUser ] = useState({})
-  const [ client, setClient ] = useState(initApolloClient(token))
 
   useEffect(() => {
-    setClient(initApolloClient(token))
-    client
+    if (!token) return
+
+    initApolloClient(token)
       .query({ query: CURRENT_USER })
       .then(res => setGithubCurrentUser(res.data.viewer))
   }, [token])
 
-  return { githubCurrentUser, client }
+  return githubCurrentUser
 }
 
 export default useGithubAuth


### PR DESCRIPTION
App.js does not need `githubCurrentUser`, so there's no reason to fire the `useEffect` hook and its background request to GitHub on initial page load. This allows us to simplify the hook and only return `githubCurrentUser`, instead of also returning `client`.

In addition, this also improves the custom hook itself:

* only run the effect if `token` is defined; return early otherwise
* since `setClient` fires asynchronously, `client` is not immediately defined; this caused 401 errors

Note that every component that needs this hook will re-fire the `useEffect` function; they are not sharing global state for `githubCurrentUser`. If the user opens many of the panels & pages that need `githubCurrentUser`, this wastes their bandwidth. On slow connections, this could become problematic. We may eventually want to move this variable to a more global context, so only the first component that needs `githubCurrentUser` fires the call to GitHub.