### PR TITLE
Discussions: address some accessibility concerns

### DIFF
--- a/apps/discussions/app/modules/Comment.js
+++ b/apps/discussions/app/modules/Comment.js
@@ -101,6 +101,7 @@ const Bottom = ({ onDelete, onEdit }) => {
         </Edit>
       )}
       <Delete
+        aria-live="polite"
         onBlur={() => setDeleting(false)}
         onClick={deleting ? onDelete : () => setDeleting(true)}
       >
@@ -118,29 +119,27 @@ const Comment = ({
 }) => {
   const [editing, setEditing] = useState(false)
 
-  if (editing) {
-    const update = async updated => {
-      await onSave({ id, text: updated.text, revisions, postCid })
-      setEditing(false)
-    }
+  const update = async updated => {
+    await onSave({ id, text: updated.text, revisions, postCid })
+    setEditing(false)
+  }
 
-    return (
-      <CommentCard>
+  return (
+    <CommentCard>
+      {editing ? (
         <CommentForm
           defaultValue={text}
           onCancel={() => setEditing(false)}
           onSave={update}
         />
-      </CommentCard>
-    )
-  }
-
-  return (
-    <CommentCard>
-      <Top author={author} createdAt={createdAt} />
-      {text}
-      {author === currentUser && (
-        <Bottom onDelete={onDelete} onEdit={() => setEditing(true)} />
+      ) : (
+        <React.Fragment>
+          <Top author={author} createdAt={createdAt} />
+          {text}
+          {author === currentUser && (
+            <Bottom onDelete={onDelete} onEdit={() => setEditing(true)} />
+          )}
+        </React.Fragment>
       )}
     </CommentCard>
   )

--- a/apps/discussions/app/modules/CommentForm.js
+++ b/apps/discussions/app/modules/CommentForm.js
@@ -68,7 +68,7 @@ const CommentForm = ({ defaultValue, onCancel, onSave }) => {
           value={text}
         />
         <Hint>
-          <Text monospace>
+          <Text monospace aria-hidden>
             *bold* &nbsp;&nbsp; _italics_ &nbsp;&nbsp; ### heading &nbsp;&nbsp;
             &gt; quote
           </Text>
@@ -82,6 +82,7 @@ const CommentForm = ({ defaultValue, onCancel, onSave }) => {
       </Field>
       <Buttons cancelling={cancelInProgress}>
         <Button
+          aria-live="polite"
           css={`
             ${cancelInProgress
               ? ''


### PR DESCRIPTION
For some reason the `aria-live` elements here seem to get registered twice, at least by Voice Over. This causes the updated content to be read twice.

* Click "Delete", Voice Over speaks out "Confirm delete; Confirm delete"
* Click "Edit", Voice Over speaks out the new card contents, then at the end says "Cancel; Cancel"
* Click "Cancel", Voice Over speaks out "Confirm Cancel; Confirm Cancel"

I was unable to determine why this happens. The most relevant information I found is a slightly different problem affecting nvda, a different screen reader: https://github.com/nvaccess/nvda/issues/7996

Having spent an hour or so researching this problem, I decided to punt on it for now. The new interaction is still more understandable than the old, when using a screen reader; the double-reading seems only slightly confusing, compared to sitting there wondering what happened when the button text changes and the screen reader says nothing at all. We can come back to this later.