### PR TITLE
chore/remove husky pre-push and post-checkout hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lerna run --concurrency 1 --stream precommit",
-      "pre-push": "npm test",
-      "post-checkout": "npm prune && npm i"
+      "pre-commit": "lerna run --concurrency 1 --stream precommit"
     }
   }
 }


### PR DESCRIPTION
These hooks are very time-costly and have some unintended side effects. I think the linting hook is a great idea and should remain, but the others should be removed for the time being