### PR TITLE
Remove partial ACL guards on discussions:

### DIFF
--- a/apps/discussions/arapp.json
+++ b/apps/discussions/arapp.json
@@ -1,11 +1,5 @@
 {
-  "roles": [
-    {
-      "name": "Add a discussion post",
-      "id": "DISCUSSION_POSTER_ROLE",
-      "params": []
-    }
-  ],
+  "roles": [],
   "environments": {
     "default": {
       "network": "development",

--- a/apps/planning-suite-kit/contracts/PlanningKit.sol
+++ b/apps/planning-suite-kit/contracts/PlanningKit.sol
@@ -99,7 +99,7 @@ contract PlanningKit is KitBase {
         DiscussionApp discussions;
 
         (vault, voting) = createA1Apps(root, acl, dao);
-        (discussions) = createDiscussionApp(root, acl, dao);
+        (discussions) = createDiscussionApp(root, dao);
 
         createTPSApps(root, dao, vault, voting, discussions);
 
@@ -310,11 +310,10 @@ contract PlanningKit is KitBase {
         acl.grantPermission(rewards, vault, vault.TRANSFER_ROLE());
     }
 
-    function createDiscussionApp(address root, ACL acl, Kernel dao) internal returns (DiscussionApp app) {
+    function createDiscussionApp(address root, Kernel dao) internal returns (DiscussionApp app) {
         bytes32 appId = apmNamehash("discussions");
         app = DiscussionApp(dao.newAppInstance(appId, latestVersionAppBase(appId)));
         app.initialize();
-        acl.createPermission(ANY_ENTITY, app, app.DISCUSSION_POSTER_ROLE(), root);
     }
 
     function handleCleanupPermissions(Kernel dao, ACL acl, address root) internal {


### PR DESCRIPTION
- This iteration is intended to be open for everyone
- Role was remove from arapp.json
- Permission setup wiped from the PlanningKit template
- ACL variable does not need to be passed to the createDiscussionApp anymore

cc: @Schwartz10 